### PR TITLE
Record replays before action and implement incremental saving

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -92,6 +92,14 @@ namespace OpenRCT2
         MemoryStream data;
     };
 
+    enum class ReplayEntryType : uint8_t
+    {
+        Action = 0,
+        Checksum = 1,
+        Snapshot = 2,
+        End = 0xFF,
+    };
+
     struct ReplayRecordData
     {
         uint32_t magic;
@@ -113,9 +121,10 @@ namespace OpenRCT2
 
     class ReplayManager final : public IReplayManager
     {
-        static constexpr uint16_t kReplayVersion = 11;
+        static constexpr uint16_t kReplayVersion = 12;
         static constexpr uint16_t kReplayMinCompatVersion = 10;
-        static constexpr uint32_t kReplayMagic = 0x5243524F; // ORCR.
+        static constexpr uint32_t kReplayMagic = 0x5243524F;    // ORCR.
+        static constexpr uint32_t kReplayMagicTmp = 0x5452434F; // ORCT.
         static constexpr int kReplayCompressionLevel = 18;
         static constexpr int kNormalRecordingChecksumTicks = 1;
         static constexpr int kSilentRecordingChecksumTicks = 40; // Same as network server
@@ -167,11 +176,42 @@ namespace OpenRCT2
 
             auto ga = Clone(action);
 
-            _currentRecording->commands.emplace(tick, std::move(ga), _commandId++);
+            ReplayCommand command(tick, std::move(ga), _commandId++);
+
+            if (_incrementalSerialiser != nullptr)
+            {
+                try
+                {
+                    *_incrementalSerialiser << ReplayEntryType::Action;
+                    SerialiseCommand(*_incrementalSerialiser, command);
+                    _incrementalFileStream->Flush();
+                }
+                catch (const std::exception& ex)
+                {
+                    LOG_ERROR("Failed to write incremental action: %s", ex.what());
+                }
+            }
+
+            _currentRecording->commands.emplace(std::move(command));
         }
 
         void AddChecksum(uint32_t tick, EntitiesChecksum&& checksum)
         {
+            if (_incrementalSerialiser != nullptr)
+            {
+                try
+                {
+                    *_incrementalSerialiser << ReplayEntryType::Checksum;
+                    *_incrementalSerialiser << tick;
+                    *_incrementalSerialiser << checksum.raw;
+                    _incrementalFileStream->Flush();
+                }
+                catch (const std::exception& ex)
+                {
+                    LOG_ERROR("Failed to write incremental checksum: %s", ex.what());
+                }
+            }
+
             _currentRecording->checksums.emplace_back(std::make_pair(tick, std::move(checksum)));
         }
 
@@ -295,6 +335,46 @@ namespace OpenRCT2
             _recordType = rt;
             _nextChecksumTick = currentTicks + 1;
 
+            // Incremental saving start
+            try
+            {
+                fs::path filePath = _currentRecording->filePath;
+                if (filePath.is_relative())
+                {
+                    if (filePath.extension() != ".parkrep")
+                        filePath += ".parkrep";
+                    fs::path replayPath = GetContext()->GetPlatformEnvironment().GetDirectoryPath(
+                                              DirBase::user, DirId::replayRecordings)
+                        / filePath;
+                    filePath = replayPath;
+                    _currentRecording->filePath = filePath.u8string();
+                }
+
+                _incrementalFileStream = std::make_unique<FileStream>(_currentRecording->filePath, FileMode::write);
+                _incrementalSerialiser = std::make_unique<DataSerialiser>(true, *_incrementalFileStream);
+
+                // Initial preamble (Magic/Version will be Tmp/12)
+                uint32_t oldMagic = _currentRecording->magic;
+                uint32_t oldTickEnd = _currentRecording->tickEnd;
+                _currentRecording->magic = kReplayMagicTmp;
+                _currentRecording->tickEnd = 0xFFFFFFFF; // Mark as live/crashed
+                SerialisePreamble(*_incrementalSerialiser, *_currentRecording);
+                _currentRecording->magic = oldMagic;
+                _currentRecording->tickEnd = oldTickEnd;
+
+                // Write the initial snapshot incrementally as well
+                *_incrementalSerialiser << ReplayEntryType::Snapshot;
+                *_incrementalSerialiser << _currentRecording->gameStateSnapshots;
+
+                _incrementalFileStream->Flush();
+            }
+            catch (const std::exception& ex)
+            {
+                LOG_ERROR("Failed to start incremental recording: %s", ex.what());
+                _incrementalSerialiser.reset();
+                _incrementalFileStream.reset();
+            }
+
             return true;
         }
 
@@ -321,6 +401,23 @@ namespace OpenRCT2
 
             TakeGameStateSnapshot(_currentRecording->gameStateSnapshots);
 
+            if (_incrementalSerialiser != nullptr)
+            {
+                try
+                {
+                    *_incrementalSerialiser << ReplayEntryType::End;
+                    *_incrementalSerialiser << _currentRecording->gameStateSnapshots;
+                    _incrementalFileStream->Flush();
+                }
+                catch (const std::exception& ex)
+                {
+                    LOG_ERROR("Failed to finalise incremental recording: %s", ex.what());
+                }
+                _incrementalSerialiser.reset();
+                _incrementalFileStream.reset();
+            }
+
+            // Final compression to save space.
             // Serialise Body.
             DataSerialiser recSerialiser(true);
             Serialise(recSerialiser, *_currentRecording);
@@ -574,7 +671,19 @@ namespace OpenRCT2
             fileStream.SetPosition(0);
             DataSerialiser fileSerializer(false, fileStream);
             fileSerializer << recFile.magic;
+            if (recFile.magic != kReplayMagic && recFile.magic != kReplayMagicTmp)
+            {
+                throw std::runtime_error("Invalid replay magic");
+            }
             fileSerializer << recFile.version;
+
+            if (recFile.magic == kReplayMagicTmp)
+            {
+                // Temporary uncompressed format
+                MemoryStream data;
+                data.CopyFromStream(fileStream, fileStream.GetLength() - fileStream.GetPosition());
+                return data;
+            }
 
             if (recFile.version >= 2)
             {
@@ -718,12 +827,12 @@ namespace OpenRCT2
             return data.version >= kReplayMinCompatVersion;
         }
 
-        bool Serialise(DataSerialiser& serialiser, ReplayRecordData& data)
+        bool SerialisePreamble(DataSerialiser& serialiser, ReplayRecordData& data)
         {
             serialiser << data.magic;
-            if (data.magic != kReplayMagic)
+            if (data.magic != kReplayMagic && data.magic != kReplayMagicTmp)
             {
-                LOG_ERROR("Magic does not match %08X, expected: %08X", data.magic, kReplayMagic);
+                LOG_ERROR("Magic does not match %08X", data.magic);
                 return false;
             }
             serialiser << data.version;
@@ -752,42 +861,129 @@ namespace OpenRCT2
             serialiser << data.tickStart;
             serialiser << data.tickEnd;
 
-            uint32_t countCommands = static_cast<uint32_t>(data.commands.size());
-            serialiser << countCommands;
+            return true;
+        }
 
-            if (serialiser.IsSaving())
+        bool Serialise(DataSerialiser& serialiser, ReplayRecordData& data)
+        {
+            if (!SerialisePreamble(serialiser, data))
+                return false;
+
+            if (data.version >= 12)
             {
-                for (auto& command : data.commands)
+                if (serialiser.IsSaving())
                 {
-                    SerialiseCommand(serialiser, const_cast<ReplayCommand&>(command));
+                    // For version 12+, we save snapshots first (usually just the one at the start)
+                    if (data.gameStateSnapshots.GetLength() > 0)
+                    {
+                        serialiser << ReplayEntryType::Snapshot;
+                        serialiser << data.gameStateSnapshots;
+                    }
+
+                    for (auto& command : data.commands)
+                    {
+                        serialiser << ReplayEntryType::Action;
+                        SerialiseCommand(serialiser, const_cast<ReplayCommand&>(command));
+                    }
+                    for (auto& checksum : data.checksums)
+                    {
+                        serialiser << ReplayEntryType::Checksum;
+                        serialiser << checksum.first;
+                        serialiser << checksum.second.raw;
+                    }
+                    serialiser << ReplayEntryType::End;
+                }
+                else
+                {
+                    ReplayEntryType type;
+                    try
+                    {
+                        while (true)
+                        {
+                            serialiser << type;
+                            if (type == ReplayEntryType::End)
+                            {
+                                break;
+                            }
+                            if (type == ReplayEntryType::Action)
+                            {
+                                ReplayCommand command = {};
+                                SerialiseCommand(serialiser, command);
+                                data.commands.emplace(std::move(command));
+                            }
+                            else if (type == ReplayEntryType::Checksum)
+                            {
+                                uint32_t tick;
+                                EntitiesChecksum checksum;
+                                serialiser << tick;
+                                serialiser << checksum.raw;
+                                data.checksums.emplace_back(tick, std::move(checksum));
+                            }
+                            else if (type == ReplayEntryType::Snapshot)
+                            {
+                                serialiser << data.gameStateSnapshots;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    catch (const std::exception&)
+                    {
+                        LOG_WARNING("Replay file is truncated or corrupted.");
+                    }
                 }
             }
             else
             {
-                for (uint32_t i = 0; i < countCommands; i++)
-                {
-                    ReplayCommand command = {};
-                    SerialiseCommand(serialiser, command);
+                uint32_t countCommands = static_cast<uint32_t>(data.commands.size());
+                serialiser << countCommands;
 
-                    data.commands.emplace(std::move(command));
+                if (serialiser.IsSaving())
+                {
+                    for (auto& command : data.commands)
+                    {
+                        SerialiseCommand(serialiser, const_cast<ReplayCommand&>(command));
+                    }
+                }
+                else
+                {
+                    for (uint32_t i = 0; i < countCommands; i++)
+                    {
+                        ReplayCommand command = {};
+                        SerialiseCommand(serialiser, command);
+
+                        data.commands.emplace(std::move(command));
+                    }
+                }
+
+                uint32_t countChecksums = static_cast<uint32_t>(data.checksums.size());
+                serialiser << countChecksums;
+
+                if (serialiser.IsLoading())
+                {
+                    data.checksums.resize(countChecksums);
+                }
+
+                for (uint32_t i = 0; i < countChecksums; i++)
+                {
+                    serialiser << data.checksums[i].first;
+                    serialiser << data.checksums[i].second.raw;
                 }
             }
 
-            uint32_t countChecksums = static_cast<uint32_t>(data.checksums.size());
-            serialiser << countChecksums;
-
-            if (serialiser.IsLoading())
+            if (data.version < 12)
             {
-                data.checksums.resize(countChecksums);
+                try
+                {
+                    serialiser << data.gameStateSnapshots;
+                }
+                catch (const std::exception&)
+                {
+                    LOG_WARNING("Replay snapshots are missing (likely truncated).");
+                }
             }
-
-            for (uint32_t i = 0; i < countChecksums; i++)
-            {
-                serialiser << data.checksums[i].first;
-                serialiser << data.checksums[i].second.raw;
-            }
-
-            serialiser << data.gameStateSnapshots;
             return true;
         }
 
@@ -887,6 +1083,9 @@ namespace OpenRCT2
         uint32_t _nextChecksumTick = 0;
         uint32_t _nextReplayTick = 0;
         RecordType _recordType = RecordType::NORMAL;
+
+        std::unique_ptr<IStream> _incrementalFileStream;
+        std::unique_ptr<DataSerialiser> _incrementalSerialiser;
     };
 
     std::unique_ptr<IReplayManager> CreateReplayManager()

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -895,7 +895,7 @@ namespace OpenRCT2
                 }
                 else
                 {
-                    ReplayEntryType type;
+                    ReplayEntryType type{};
                     try
                     {
                         while (true)
@@ -913,7 +913,7 @@ namespace OpenRCT2
                             }
                             else if (type == ReplayEntryType::Checksum)
                             {
-                                uint32_t tick;
+                                uint32_t tick = 0;
                                 EntitiesChecksum checksum;
                                 serialiser << tick;
                                 serialiser << checksum.raw;

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -356,7 +356,8 @@ namespace OpenRCT2::GameActions
 
                 // When using verbose logging also log what we are about to do.
                 // We create a temporary string to avoid messing with the main log output.
-                std::string logLine = std::string(static_cast<const char*>(logContext.output.GetData()), logContext.output.GetLength());
+                std::string logLine = std::string(
+                    static_cast<const char*>(logContext.output.GetData()), logContext.output.GetLength());
                 logLine += ") [Executing]";
                 LOG_VERBOSE("%s", logLine.c_str());
             }

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -353,6 +353,32 @@ namespace OpenRCT2::GameActions
             if (topLevel && !flags.has(CommandFlag::ghost))
             {
                 LogActionBegin(gameState, logContext, action);
+
+                // When using verbose logging also log what we are about to do.
+                // We create a temporary string to avoid messing with the main log output.
+                std::string logLine = std::string(static_cast<const char*>(logContext.output.GetData()), logContext.output.GetLength());
+                logLine += ") [Executing]";
+                LOG_VERBOSE("%s", logLine.c_str());
+            }
+
+            // If not a ghost and not a client-only action, record it in the replay if we are recording.
+            // This is done BEFORE execution to ensure crashes during execution are captured.
+            if (topLevel && !(actionFlags & Flags::ClientOnly) && Network::GetMode() == Network::Mode::none)
+            {
+                bool commandExecutes = !flags.hasAny(CommandFlag::ghost, CommandFlag::noSpend);
+                if (replayManager != nullptr && !ignoreForReplays)
+                {
+                    bool recordAction = false;
+                    if (replayManager->IsRecording() && commandExecutes)
+                        recordAction = true;
+                    else if (replayManager->IsNormalising() && flags.has(CommandFlag::replay))
+                        recordAction = true; // In normalisation we only feed back actions issued by the replay manager.
+
+                    if (recordAction)
+                    {
+                        replayManager->AddGameAction(gameState.currentTicks, action);
+                    }
+                }
             }
 
             // Execute the action, changing the game state
@@ -401,23 +427,6 @@ namespace OpenRCT2::GameActions
                     if (!result.position.IsNull())
                     {
                         Network::SetPlayerLastActionCoord(playerIndex, result.position);
-                    }
-                }
-                else
-                {
-                    bool commandExecutes = !flags.hasAny(CommandFlag::ghost, CommandFlag::noSpend);
-
-                    bool recordAction = false;
-                    if (replayManager != nullptr && !ignoreForReplays)
-                    {
-                        if (replayManager->IsRecording() && commandExecutes)
-                            recordAction = true;
-                        else if (replayManager->IsNormalising() && flags.has(CommandFlag::replay))
-                            recordAction = true; // In normalisation we only feed back actions issued by the replay manager.
-                    }
-                    if (recordAction)
-                    {
-                        replayManager->AddGameAction(gameState.currentTicks, action);
                     }
                 }
             }

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -189,6 +189,11 @@ namespace OpenRCT2
         _fileSize = std::max(_fileSize, position);
     }
 
+    void FileStream::Flush()
+    {
+        fflush(_file);
+    }
+
     uint64_t FileStream::TryRead(void* buffer, uint64_t length)
     {
         size_t readBytes = fread(buffer, 1, static_cast<size_t>(length), _file);

--- a/src/openrct2/core/FileStream.h
+++ b/src/openrct2/core/FileStream.h
@@ -51,6 +51,7 @@ namespace OpenRCT2
         void Seek(int64_t offset, int32_t origin) override;
         void Read(void* buffer, uint64_t length) override;
         void Write(const void* buffer, uint64_t length) override;
+        void Flush() override;
         uint64_t TryRead(void* buffer, uint64_t length) override;
     };
 

--- a/src/openrct2/core/IStream.hpp
+++ b/src/openrct2/core/IStream.hpp
@@ -57,6 +57,10 @@ namespace OpenRCT2
         virtual void Read(void* buffer, uint64_t length) = 0;
         virtual void Write(const void* buffer, uint64_t length) = 0;
 
+        virtual void Flush()
+        {
+        }
+
         virtual uint64_t TryRead(void* buffer, uint64_t length) = 0;
 
         virtual const void* GetData() const


### PR DESCRIPTION
This change improves the replay system to capture actions that cause crashes by recording them before they are executed. It also introduces incremental saving to ensure that replay data is not lost if the game crashes during recording. The replay version is bumped to 12, featuring a robust tag-based interleaved format that handles actions, checksums, and snapshots consistently. The loader has been updated to handle truncated replays and recover from the new uncompressed temporary format.

---
*PR created automatically by Jules for task [15925491463891860277](https://jules.google.com/task/15925491463891860277) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replay system now supports incremental recording, enabling live replay data writing and recovery from interrupted recordings.
  * Added verbose logging for game action execution to improve debugging and diagnostics.

* **Refactor**
  * Enhanced stream handling with flush capability for improved data persistence and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->