### PR TITLE
Optimize Android CI setup and Gradle caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ env:
   OPENRCT2_ORG_TOKEN: ${{ secrets.OPENRCT2_ORG_TOKEN }}
   BACKTRACE_IO_TOKEN: ${{ secrets.BACKTRACE_IO_TOKEN }}
   OPENRCT2_VERSION: 0.4.31
+  ANDROID_IMAGE: ghcr.io/openrct2/openrct2-build:26-android
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -612,7 +613,7 @@ jobs:
   android-libs:
     name: Android (${{ matrix.arch }})
     runs-on: ubuntu-latest
-    needs: [check-code-formatting, build_variables, g2dat]
+    needs: [check-code-formatting, build_variables]
     container: ghcr.io/openrct2/openrct2-build:26-android
     strategy:
       fail-fast: false
@@ -631,14 +632,16 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ hashFiles('src/openrct2-android/gradle.properties') }}
+          key: gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-${{ hashFiles('src/openrct2-android/**/*.gradle*', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties', 'src/openrct2-android/gradle.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build Native Libs
         run: |
           . scripts/setenv
           pushd src/openrct2-android
-          ./gradlew app:externalNativeBuildRelease -PabiFilter=${{ matrix.arch }}
+          ./gradlew app:externalNativeBuildRelease -PabiFilter=${{ matrix.arch }} -PskipAssets -PskipJava
           popd
       - name: Upload Native Libs
         uses: actions/upload-artifact@v6
@@ -650,8 +653,8 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-latest
-    needs: [android-libs, build_variables]
-    container: openrct2/openrct2-build:25-android
+    needs: [android-libs, build_variables, g2dat]
+    container: ghcr.io/openrct2/openrct2-build:26-android
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -661,7 +664,9 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ hashFiles('src/openrct2-android/gradle.properties') }}
+          key: gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-${{ hashFiles('src/openrct2-android/**/*.gradle*', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties', 'src/openrct2-android/gradle.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-
       - name: Setup keystore
         run: |
           echo "${{ secrets.OPENRCT2_KEYSTORE_CONTENTS }}" | base64 -d > keystore.jks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/**/*.gradle','src/openrct2-android/**/*.properties') }}
+          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/build.gradle', 'src/openrct2-android/settings.gradle', 'src/openrct2-android/app/build.gradle', 'src/openrct2-android/gradle.properties', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-26-android-
       - name: Install GCC problem matcher
@@ -664,7 +664,7 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/**/*.gradle','src/openrct2-android/**/*.properties') }}
+          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/build.gradle', 'src/openrct2-android/settings.gradle', 'src/openrct2-android/app/build.gradle', 'src/openrct2-android/gradle.properties', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-26-android-
       - name: Setup keystore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,9 +632,9 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-${{ hashFiles('src/openrct2-android/**/*.gradle*', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties', 'src/openrct2-android/gradle.properties') }}
+          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/**/*.gradle','src/openrct2-android/**/*.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-
+            gradle-${{ runner.os }}-26-android-
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build Native Libs
@@ -664,9 +664,9 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-${{ hashFiles('src/openrct2-android/**/*.gradle*', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties', 'src/openrct2-android/gradle.properties') }}
+          key: gradle-${{ runner.os }}-26-android-${{ hashFiles('src/openrct2-android/**/*.gradle','src/openrct2-android/**/*.properties') }}
           restore-keys: |
-            gradle-${{ runner.os }}-${{ env.ANDROID_IMAGE }}-
+            gradle-${{ runner.os }}-26-android-
       - name: Setup keystore
         run: |
           echo "${{ secrets.OPENRCT2_KEYSTORE_CONTENTS }}" | base64 -d > keystore.jks

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -92,7 +92,27 @@ tasks.register('prepareOpenRCT2Assets', Exec) {
     outputs.dir("${projectDir}/src/main/assets/openrct2")
 }
 
-preBuild.dependsOn(tasks.named('prepareOpenRCT2Assets'))
+if (!project.hasProperty('skipAssets')) {
+    preBuild.dependsOn(tasks.named('prepareOpenRCT2Assets'))
+}
+
+if (project.hasProperty('skipJava')) {
+    tasks.withType(JavaCompile).configureEach {
+        enabled = false
+    }
+    def skippablePrefixes = ["process", "merge", "generate", "compile", "lint", "check"]
+    def skippableKeywords = ["Java", "Resources", "Manifest", "Asset", "Lint", "Runtime"]
+    tasks.configureEach { task ->
+        def name = task.name
+        def hasPrefix = skippablePrefixes.any { name.startsWith(it) }
+        def hasKeyword = skippableKeywords.any { name.contains(it) }
+        if (hasPrefix && hasKeyword) {
+            if (!name.contains("externalNativeBuild") && !name.contains("CMake") && !name.contains("Ninja")) {
+                task.enabled = false
+            }
+        }
+    }
+}
 
 dependencies {
     implementation 'commons-io:commons-io:2.20.0'


### PR DESCRIPTION
Optimized Android CI by separating native builds from asset preparation and improving the Gradle cache strategy.

---
*PR created automatically by Jules for task [8406301954616771286](https://jules.google.com/task/8406301954616771286) started by @janisozaur*