### PR TITLE
Fix: Implement and enforce RLE sprite bounds checking during object load

### DIFF
--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -15,7 +15,7 @@
 
 using namespace OpenRCT2::Drawing;
 
-template<DrawBlendOp TBlendOp>
+template<DrawBlendOp TBlendOp, bool TCheckBounds = false>
 static bool FASTCALL DrawRLESpriteMagnify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& paletteMap = args.PalMap;
@@ -28,12 +28,46 @@ static bool FASTCALL DrawRLESpriteMagnify(RenderTarget& rt, const DrawSpriteArgs
     auto zoom = rt.zoom_level;
     auto dstLineWidth = rt.LineStride();
 
+    // Bounds checking setup
+    const uint8_t* srcEnd = nullptr;
+    if constexpr (TCheckBounds)
+    {
+        if (args.SourceImage.size == 0)
+        {
+            printf("%s:%d: Invalid sprite data: no size information\n", __FILE__, __LINE__);
+            return false; // Invalid sprite data: no size information
+        }
+        srcEnd = imgData + args.SourceImage.size;
+    }
+
     for (int32_t y = 0; y < height; y++)
     {
         PaletteIndex* nextDst = dst + dstLineWidth;
         const int32_t rowNum = zoom.ApplyTo(srcY + y);
+
+        if constexpr (TCheckBounds)
+        {
+            // Check line offset table bounds
+            const size_t lineOffsetPos = static_cast<size_t>(rowNum) * sizeof(uint16_t);
+            if (lineOffsetPos + 1 >= args.SourceImage.size)
+            {
+                printf("%s:%d: Line offset table out of bounds\n", __FILE__, __LINE__);
+                return false; // Line offset table out of bounds
+            }
+        }
+
         uint16_t lineOffset;
         std::memcpy(&lineOffset, &imgData[rowNum * sizeof(uint16_t)], sizeof(uint16_t));
+
+        if constexpr (TCheckBounds)
+        {
+            if (lineOffset >= args.SourceImage.size)
+            {
+                printf("%s:%d: Line offset points beyond sprite data\n", __FILE__, __LINE__);
+                return false; // Line offset points beyond sprite data
+            }
+        }
+
         const uint8_t* data8 = imgData + lineOffset;
 
         bool lastDataForLine = false;
@@ -46,10 +80,31 @@ static bool FASTCALL DrawRLESpriteMagnify(RenderTarget& rt, const DrawSpriteArgs
             while (colNum >= pixelRunStart + numPixels && !lastDataForLine)
             {
                 data8 += numPixels;
+
+                if constexpr (TCheckBounds)
+                {
+                    // Check we can read chunk header (2 bytes)
+                    if (data8 + 2 > srcEnd)
+                    {
+                        printf("%s:%d: Chunk header out of bounds\n", __FILE__, __LINE__);
+                        return false; // Chunk header out of bounds
+                    }
+                }
+
                 numPixels = *data8++;
                 pixelRunStart = *data8++;
                 lastDataForLine = numPixels & 0x80;
                 numPixels &= 0x7F;
+
+                if constexpr (TCheckBounds)
+                {
+                    // Check pixel data bounds
+                    if (data8 + numPixels > srcEnd)
+                    {
+                        printf("%s:%d: Pixel data out of bounds\n", __FILE__, __LINE__);
+                        return false; // Pixel data out of bounds
+                    }
+                }
             }
             if (pixelRunStart <= colNum && colNum < pixelRunStart + numPixels)
                 BlitPixel<TBlendOp>(reinterpret_cast<const PaletteIndex*>(data8 + colNum - pixelRunStart), dst, paletteMap);
@@ -213,7 +268,7 @@ static bool FASTCALL DrawRLESprite(RenderTarget& rt, const DrawSpriteArgs& args)
     {
         case -2:
         case -1:
-            return DrawRLESpriteMagnify<TBlendOp>(rt, args);
+            return DrawRLESpriteMagnify<TBlendOp, TCheckBounds>(rt, args);
         case 0:
             return DrawRLESpriteMinify<TBlendOp, 0, TCheckBounds>(rt, args);
         case 1:
@@ -269,5 +324,5 @@ bool FASTCALL GfxRleSpriteToBuffer(RenderTarget& rt, const DrawSpriteArgs& args)
  */
 bool FASTCALL GfxRleSpriteToBufferWithBoundsCheck(RenderTarget& rt, const DrawSpriteArgs& args)
 {
-    return GfxRleSpriteToBufferInternal<false>(rt, args);
+    return GfxRleSpriteToBufferInternal<true>(rt, args);
 }

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -104,10 +104,9 @@ namespace OpenRCT2
                 {
                     for (auto i : range)
                     {
-                        result.push_back(
-                            std::make_unique<RequiredImage>(
-                                static_cast<uint32_t>(SPR_CSG_BEGIN + i),
-                                [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
+                        result.push_back(std::make_unique<RequiredImage>(
+                            static_cast<uint32_t>(SPR_CSG_BEGIN + i),
+                            [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
                     }
                 }
                 else
@@ -132,9 +131,8 @@ namespace OpenRCT2
                 auto range = ParseRange(rangeString);
                 for (auto i : range)
                 {
-                    result.push_back(
-                        std::make_unique<RequiredImage>(
-                            static_cast<uint32_t>(i), [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
+                    result.push_back(std::make_unique<RequiredImage>(
+                        static_cast<uint32_t>(i), [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
                 }
             }
         }
@@ -316,9 +314,8 @@ namespace OpenRCT2
             {
                 if (i >= 0 && i < numImages)
                 {
-                    result.push_back(
-                        std::make_unique<RequiredImage>(
-                            static_cast<uint32_t>(i), [images](uint32_t idx) -> const G1Element* { return &images[idx]; }));
+                    result.push_back(std::make_unique<RequiredImage>(
+                        static_cast<uint32_t>(i), [images](uint32_t idx) -> const G1Element* { return &images[idx]; }));
                 }
                 else
                 {
@@ -708,8 +705,7 @@ namespace OpenRCT2
 
             if (!isValid)
             {
-                auto message = String::stdFormat(
-                    "Image %zu contains malformed RLE sprite data.", i);
+                auto message = String::stdFormat("Image %zu contains malformed RLE sprite data.", i);
                 context->LogError(ObjectError::invalidProperty, message.c_str());
                 allValid = false;
             }

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -521,7 +521,10 @@ namespace OpenRCT2
             _entries.insert(_entries.end(), newEntries.begin(), newEntries.end());
 
             // Validate all loaded images for malformed RLE sprite data
-            ValidateImages(context);
+            if (!ValidateImages(context))
+            {
+                throw std::runtime_error("RLE validation failed");
+            }
         }
         catch (const std::exception&)
         {
@@ -657,13 +660,18 @@ namespace OpenRCT2
         _objDataCache.clear();
 
         // Validate all loaded images for malformed RLE sprite data
-        ValidateImages(context);
+        if (!ValidateImages(context))
+        {
+            return false;
+        }
 
         return usesFallbackSprites;
     }
 
-    void ImageTable::ValidateImages(IReadObjectContext* context)
+    bool ImageTable::ValidateImages(IReadObjectContext* context)
     {
+        bool allValid = true;
+
         // Validate each RLE-compressed image for bounds violations
         for (size_t i = 0; i < _entries.size(); i++)
         {
@@ -683,7 +691,7 @@ namespace OpenRCT2
 
             // Create a temporary dummy buffer and render target for validation
             // We don't need the actual output, just to check if the sprite data is valid
-            std::vector<uint8_t> dummyBuffer(g1.width * g1.height);
+            std::vector<uint8_t> dummyBuffer(std::max<int32_t>(1, g1.width) * std::max<int32_t>(1, g1.height));
             auto* paletteBits = reinterpret_cast<OpenRCT2::Drawing::PaletteIndex*>(dummyBuffer.data());
             OpenRCT2::Drawing::RenderTarget rt;
             rt.bits = paletteBits;
@@ -701,10 +709,13 @@ namespace OpenRCT2
             if (!isValid)
             {
                 auto message = String::stdFormat(
-                    "Image %zu contains malformed RLE sprite data and may cause rendering issues.", i);
-                context->LogWarning(ObjectError::invalidProperty, message.c_str());
+                    "Image %zu contains malformed RLE sprite data.", i);
+                context->LogError(ObjectError::invalidProperty, message.c_str());
+                allValid = false;
             }
         }
+
+        return allValid;
     }
 
     void ImageTable::AddImage(const G1Element* g1)

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -59,7 +59,7 @@ namespace OpenRCT2
          * @note root is deliberately left non-const: json_t behaviour changes when const
          */
         bool ReadJson(IReadObjectContext* context, json_t& root);
-        void ValidateImages(IReadObjectContext* context);
+        bool ValidateImages(IReadObjectContext* context);
         const G1Element* GetImages() const
         {
             return _entries.data();

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -314,6 +314,7 @@ namespace OpenRCT2::ObjectFactory
         catch (const std::exception& e)
         {
             LOG_ERROR("Error: %s when processing object %s", e.what(), path);
+            result.reset();
         }
         return result;
     }
@@ -338,6 +339,7 @@ namespace OpenRCT2::ObjectFactory
             if (readContext.WasError())
             {
                 LOG_ERROR("Error when processing object.");
+                result.reset();
             }
             else
             {

--- a/test/tests/RleSpriteTests.cpp
+++ b/test/tests/RleSpriteTests.cpp
@@ -184,10 +184,10 @@ namespace
     {
         // 2x2 image, valid data
         std::vector<uint8_t> data = {
-            0x04, 0x00, // Line 0 offset (4)
-            0x08, 0x00, // Line 1 offset (8)
-            2, 0, 0x11, 0x22, // Line 0: 2 pixels at 0: 0x11, 0x22
-            2 | 0x80, 0, 0x33, 0x44 // Line 1: 2 pixels at 0: 0x33, 0x44 (end of line)
+            0x04,     0x00,             // Line 0 offset (4)
+            0x08,     0x00,             // Line 1 offset (8)
+            2,        0,    0x11, 0x22, // Line 0: 2 pixels at 0: 0x11, 0x22
+            2 | 0x80, 0,    0x33, 0x44  // Line 1: 2 pixels at 0: 0x33, 0x44 (end of line)
         };
 
         G1Element g1{};
@@ -217,7 +217,7 @@ namespace
         // 1x1 image, but data says it has a run of 10 pixels, and we only provide 2 bytes of data
         std::vector<uint8_t> data = {
             0x02, 0x00, // Line 0 offset (2)
-            10, 0,      // 10 pixels, start at 0
+            10,   0,    // 10 pixels, start at 0
             0xAA, 0xBB  // Only 2 pixels provided
         };
 

--- a/test/tests/RleSpriteTests.cpp
+++ b/test/tests/RleSpriteTests.cpp
@@ -180,4 +180,113 @@ namespace
             RleDrawParam{ 1, 0, 0 }, RleDrawParam{ 1, -1, -1 }, RleDrawParam{ 1, 1, 0 }, RleDrawParam{ 2, 0, 1 },
             RleDrawParam{ 2, -1, 0 }, RleDrawParam{ 3, 0, -1 }));
 
+    TEST(RleSpriteTests, ValidRleDataPasses)
+    {
+        // 2x2 image, valid data
+        std::vector<uint8_t> data = {
+            0x04, 0x00, // Line 0 offset (4)
+            0x08, 0x00, // Line 1 offset (8)
+            2, 0, 0x11, 0x22, // Line 0: 2 pixels at 0: 0x11, 0x22
+            2 | 0x80, 0, 0x33, 0x44 // Line 1: 2 pixels at 0: 0x33, 0x44 (end of line)
+        };
+
+        G1Element g1{};
+        g1.width = 2;
+        g1.height = 2;
+        g1.offset = data.data();
+        g1.size = static_cast<uint32_t>(data.size());
+        g1.flags = G1Flag::hasRLECompression;
+
+        std::vector<uint8_t> buffer(4);
+        auto* paletteBits = reinterpret_cast<OpenRCT2::Drawing::PaletteIndex*>(buffer.data());
+        OpenRCT2::Drawing::RenderTarget rt;
+        rt.bits = paletteBits;
+        rt.width = 2;
+        rt.height = 2;
+        rt.pitch = 0;
+        rt.zoom_level = ZoomLevel{ 0 };
+
+        DrawSpriteArgs args(ImageId(), PaletteMap::GetDefault(), g1, 0, 0, 2, 2, paletteBits);
+
+        bool result = GfxRleSpriteToBufferWithBoundsCheck(rt, args);
+        EXPECT_TRUE(result) << "Valid RLE data should pass validation";
+    }
+
+    TEST(RleSpriteTests, MalformedRleDataDetected)
+    {
+        // 1x1 image, but data says it has a run of 10 pixels, and we only provide 2 bytes of data
+        std::vector<uint8_t> data = {
+            0x02, 0x00, // Line 0 offset (2)
+            10, 0,      // 10 pixels, start at 0
+            0xAA, 0xBB  // Only 2 pixels provided
+        };
+
+        G1Element g1{};
+        g1.width = 10;
+        g1.height = 1;
+        g1.offset = data.data();
+        g1.size = static_cast<uint32_t>(data.size());
+        g1.flags = G1Flag::hasRLECompression;
+
+        std::vector<uint8_t> buffer(10);
+        auto* paletteBits = reinterpret_cast<OpenRCT2::Drawing::PaletteIndex*>(buffer.data());
+        OpenRCT2::Drawing::RenderTarget rt;
+        rt.bits = paletteBits;
+        rt.width = 10;
+        rt.height = 1;
+        rt.pitch = 0;
+        rt.zoom_level = ZoomLevel{ 0 };
+
+        DrawSpriteArgs args(ImageId(), PaletteMap::GetDefault(), g1, 0, 0, 10, 1, paletteBits);
+
+        bool result = GfxRleSpriteToBufferWithBoundsCheck(rt, args);
+        EXPECT_FALSE(result) << "Malformed RLE data (run exceeds buffer) should be detected";
+    }
+
+    TEST(RleSpriteTests, MagnificationBoundsCheck)
+    {
+        // Malformed data: Line 0 offset points beyond buffer
+        std::vector<uint8_t> data = {
+            0x10, 0x00 // Line 0 offset (16), but data size is only 2
+        };
+
+        G1Element g1{};
+        g1.width = 10;
+        g1.height = 1;
+        g1.offset = data.data();
+        g1.size = static_cast<uint32_t>(data.size());
+        g1.flags = G1Flag::hasRLECompression;
+
+        std::vector<uint8_t> buffer(40);
+        auto* paletteBits = reinterpret_cast<OpenRCT2::Drawing::PaletteIndex*>(buffer.data());
+        OpenRCT2::Drawing::RenderTarget rt;
+        rt.bits = paletteBits;
+        rt.width = 20;
+        rt.height = 2;
+        rt.pitch = 0;
+        rt.zoom_level = ZoomLevel{ -1 }; // 2x zoom
+
+        DrawSpriteArgs args(ImageId(), PaletteMap::GetDefault(), g1, 0, 0, 10, 1, paletteBits);
+
+        bool result = GfxRleSpriteToBufferWithBoundsCheck(rt, args);
+        EXPECT_FALSE(result) << "Malformed RLE data (offset out of bounds) should be detected in magnification";
+    }
+
+    TEST(RleSpriteTests, MtrBoatFailsValidation)
+    {
+        // Initialize context
+        gOpenRCT2Headless = true;
+        auto context = CreateContext();
+        context->Initialise();
+
+        auto path = OpenRCT2::Path::Combine(TestData::GetBasePath(), "objects", "MTRBOAT.DAT");
+        if (!OpenRCT2::File::Exists(path))
+        {
+            GTEST_SKIP() << "MTRBOAT.DAT not found in testdata";
+        }
+
+        std::unique_ptr<Object> obj = OpenRCT2::ObjectFactory::CreateObjectFromFile(path, true);
+        EXPECT_EQ(obj, nullptr) << "MTRBOAT.DAT should fail RLE validation and not be loaded";
+    }
+
 } // namespace


### PR DESCRIPTION
Implemented and enforced RLE sprite bounds checking during object load to prevent crashes and OOB access. Malformed objects are now blocked and reported to the user. Added unit tests for validation.

---
*PR created automatically by Jules for task [17862468744339850785](https://jules.google.com/task/17862468744339850785) started by @janisozaur*