### PR TITLE
Update Windows CI to VS 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
             tracks.dat
   windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     needs: [check-code-formatting, build_variables, g2dat]
     strategy:
       fail-fast: false

--- a/scripts/vstool.cmd
+++ b/scripts/vstool.cmd
@@ -3,28 +3,69 @@
 rem Invokes a tool within a Visual Studio prompt
 rem Uses %PLATFORM% to set architecture of prompt
 
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Preview"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
-if exist "%vspath%" goto found
+set "vspath="
 
-:notfound
+rem Try to use vswhere to find the latest Visual Studio
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if exist "%vswhere%" (
+    for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -prerelease -property installationPath`) do (
+        set "vspath=%%i"
+    )
+)
+
+if not defined vspath (
+    for /f "usebackq tokens=*" %%i in (`vswhere -latest -prerelease -property installationPath 2^>nul`) do (
+        set "vspath=%%i"
+    )
+)
+
+if defined vspath if exist "%vspath%" goto found
+
+rem Fallback to searching common paths
+if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
+    goto found
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Community" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
+    goto found
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Professional" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Professional"
+    goto found
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Preview" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Preview"
+    goto found
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
+    goto found
+)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community" (
+    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
+    goto found
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
+    set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
+    goto found
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" (
+    set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
+    goto found
+)
+
 echo Visual Studio directory not found
 exit /b 1
 
 :found
-if "%platform%"=="x64" (
-    call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=x64
+set "vsarch=%platform%"
+if "%vsarch%"=="win32" set "vsarch=x86"
+
+if not "%vsarch%"=="" (
+    call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=%vsarch%
 ) else (
     call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo
 )

--- a/scripts/vstool.cmd
+++ b/scripts/vstool.cmd
@@ -3,6 +3,12 @@
 rem Invokes a tool within a Visual Studio prompt
 rem Uses %PLATFORM% to set architecture of prompt
 
+set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
+if exist "%vspath%" goto found
+set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
+if exist "%vspath%" goto found
+set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Preview"
+if exist "%vspath%" goto found
 set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
 if exist "%vspath%" goto found
 set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"

--- a/scripts/vstool.cmd
+++ b/scripts/vstool.cmd
@@ -10,65 +10,46 @@ set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
 
 if exist "%vswhere%" (
-    for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -prerelease -property installationPath`) do (
+    for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "vspath=%%i"
     )
 )
 
 if not defined vspath (
-    for /f "usebackq tokens=*" %%i in (`vswhere -latest -prerelease -property installationPath 2^>nul`) do (
-        set "vspath=%%i"
+    rem Fallback to searching common paths
+    if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Community" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Professional" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Professional"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Preview" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Preview"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
+    ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
+        set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
+    ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" (
+        set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
     )
 )
 
-if defined vspath if exist "%vspath%" goto found
+if not defined vspath goto notfound
+if not exist "%vspath%" goto notfound
 
-rem Fallback to searching common paths
-if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
-    goto found
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Community" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
-    goto found
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Professional" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Professional"
-    goto found
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Preview" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Preview"
-    goto found
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
-    goto found
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community" (
-    set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
-    goto found
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
-    set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
-    goto found
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" (
-    set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
-    goto found
-)
+echo Using Visual Studio from %vspath%
 
-echo Visual Studio directory not found
-exit /b 1
-
-:found
-set "vsarch=%platform%"
-if "%vsarch%"=="win32" set "vsarch=x86"
-
-if not "%vsarch%"=="" (
-    call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=%vsarch%
+if "%platform%"=="x64" (
+    call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=x64
 ) else (
     call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo
 )
 
 %*
 exit /b %errorlevel%
+
+:notfound
+echo Visual Studio directory not found
+exit /b 1


### PR DESCRIPTION
This change updates the Windows CI job to use the new `windows-2025-vs2026` image, which includes Visual Studio 2026. According to the user, VS 2026 provides faster build times.

Additionally, the `scripts/vstool.cmd` script has been updated to detect and use Visual Studio 2026 if present, while maintaining backward compatibility with VS 2022 and VS 2019.

---
*PR created automatically by Jules for task [8161314135579404070](https://jules.google.com/task/8161314135579404070) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for Visual Studio 2026 with fallbacks to 2022 and 2019.
  * Improved automatic detection of installed Visual Studio and selection of the correct build environment/architecture.
  * Updated CI Windows runner image to Windows 2025 to align with the newer Visual Studio image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->