### PR TITLE
Consolidate Windows binaries and implement --console flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,6 @@ jobs:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-unsigned-${{ matrix.platform }}
           path: |
             bin/openrct2.exe
-            bin/openrct2.com
       # Sign the binaries first, so that all other artifacts (portable, installer, symbols) use signed binaries
       - name: Sign binaries
         id: sign-binaries
@@ -252,7 +251,6 @@ jobs:
       - name: Use signed binaries
         if: ${{ needs.build_variables.outputs.sign == 'true' }}
         run: |
-          mv files-signed/openrct2.com bin/openrct2.com
           mv files-signed/openrct2.exe bin/openrct2.exe
       - name: Download graphics .dat files on ARM64
         if: matrix.platform == 'arm64'

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -5,7 +5,6 @@ Unicode True
 !define APPNAMEANDVERSION   "${APPNAME} ${APPVERSION}"
 !define APPURLLINK          "https://openrct2.io"
 !define OPENRCT2_EXE        "openrct2.exe"
-!define OPENRCT2_COM        "openrct2.com"
 
 !if "${PLATFORM}" == "Win32"
     !define APPBITS         32
@@ -224,7 +223,6 @@ Section "!OpenRCT2" Section1
 
     ; Copy executable
     File /oname=${OPENRCT2_EXE} ${BINARY_DIR}\${OPENRCT2_EXE}
-    File /oname=${OPENRCT2_COM} ${BINARY_DIR}\${OPENRCT2_COM}
 
     ; Create the Registry Entries
     WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OpenRCT2" "Comments" "Visit ${APPURLLINK}"
@@ -244,7 +242,7 @@ Section "!OpenRCT2" Section1
     CreateShortCut "$DESKTOP\OpenRCT2.lnk" "$INSTDIR\${OPENRCT2_EXE}"
     CreateDirectory "$SMPROGRAMS\$SHORTCUTS"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2.lnk" "$INSTDIR\${OPENRCT2_EXE}"
-    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2-verbose.lnk" "%WINDIR%\System32\cmd.exe" '/C "$INSTDIR\${OPENRCT2_COM}" --verbose'
+    CreateShortCut "$SMPROGRAMS\$SHORTCUTS\OpenRCT2-verbose.lnk" "$INSTDIR\${OPENRCT2_EXE}" "--console --verbose"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Uninstall.lnk" "$INSTDIR\uninstall.exe"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Readme.lnk" "$INSTDIR\Readme.txt"
     CreateShortCut "$SMPROGRAMS\$SHORTCUTS\Changelog.lnk" "$INSTDIR\Changelog.txt"
@@ -297,7 +295,6 @@ Section "Uninstall"
     Delete "$INSTDIR\scripting.md"
     Delete "$INSTDIR\openrct2.d.ts"
     Delete "$INSTDIR\${OPENRCT2_EXE}"
-    Delete "$INSTDIR\${OPENRCT2_COM}"
     Delete "$INSTDIR\INSTALL.LOG"
 
     ; Data files

--- a/scripts/build
+++ b/scripts/build
@@ -26,9 +26,7 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
     echo -e "\033[0;36mBuilding OpenRCT2 for Windows $CONFIGURATION|$PLATFORM...\033[0m"
     vstool msbuild openrct2.proj -t:build -p:Breakpad=true -p:UsePCH=true -maxcpucount
 
-    # Create openrct2.exe and openrct2.com with correct subsystem
-    cp bin/openrct2.exe bin/openrct2.com
-    vstool editbin //subsystem:console bin/openrct2.com
+    # Force openrct2.exe with correct subsystem
     vstool editbin //subsystem:windows bin/openrct2.exe
 else
     echo -e "\033[0;36mBuilding OpenRCT2...\033[0m"

--- a/scripts/build-portable
+++ b/scripts/build-portable
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
         rm $destination
     fi
     7z a -r $destination \
-        openrct2.exe openrct2.com data \
+        openrct2.exe data \
         ../contributors.md \
         ../PRIVACY.md \
         ../licence.txt \

--- a/scripts/build-symbols
+++ b/scripts/build-symbols
@@ -22,7 +22,7 @@ echo -e "\033[0;36mCreating symbols archive for OpenRCT2...\033[0m"
 if [[ -f $destination ]]; then
     rm $destination
 fi
-$archiver $destination openrct2.exe openrct2.com openrct2-win.pdb
+$archiver $destination openrct2.exe openrct2-win.pdb
 
 destination=$(cygpath -w $(readlink -f $destination))
 printf '\033[0;32m%s\033[0m\n' "${destination} created successfully"

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -48,7 +48,7 @@ if (APPLE)
 endif ()
 
 # Outputs
-add_executable(openrct2 ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
+add_executable(openrct2 WIN32 ${OPENRCT2_UI_SOURCES} ${OPENRCT2_UI_MM_SOURCES})
 add_executable(OpenRCT2::openrct2 ALIAS openrct2)
 
 SET_CHECK_CXX_FLAGS(openrct2)

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -33,8 +33,8 @@ static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW);
  * Windows entry point to OpenRCT2 with a console window using a traditional C main function.
  */
 int WINAPI wWinMain(
-    [[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance,
-    [[maybe_unused]] LPWSTR lpCmdLine, [[maybe_unused]] int nShowCmd)
+    [[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance, [[maybe_unused]] LPWSTR lpCmdLine,
+    [[maybe_unused]] int nShowCmd)
 {
     int argc;
     wchar_t** argvW = CommandLineToArgvW(GetCommandLineW(), &argc);

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -23,6 +23,7 @@
 #include <iterator>
 #include <openrct2-ui/Ui.h>
 #include <openrct2/core/String.hpp>
+#include <shellapi.h>
 #include <string>
 #include <vector>
 
@@ -31,12 +32,20 @@ static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW);
 /**
  * Windows entry point to OpenRCT2 with a console window using a traditional C main function.
  */
-int wmain(int argc, wchar_t** argvW, [[maybe_unused]] wchar_t* envp)
+int WINAPI wWinMain(
+    [[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance,
+    [[maybe_unused]] LPWSTR lpCmdLine, [[maybe_unused]] int nShowCmd)
 {
+    int argc;
+    wchar_t** argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (argvW == nullptr)
+    {
+        return 1;
+    }
+
     auto argvStrings = GetCommandLineArgs(argc, argvW);
 
-    SetConsoleCP(OpenRCT2::CodePage::UTF8);
-    SetConsoleOutputCP(OpenRCT2::CodePage::UTF8);
+    LocalFree(argvW);
 
     std::vector<const char*> argv;
     std::transform(
@@ -44,7 +53,7 @@ int wmain(int argc, wchar_t** argvW, [[maybe_unused]] wchar_t* envp)
 
     // Ensure that argv[argc] == nullptr, as mandated by the standard
     argv.push_back(nullptr);
-    return NormalisedMain(argc, argv.data());
+    return NormalisedMain(static_cast<int>(argv.size()) - 1, argv.data());
 }
 
 static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW)

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -61,7 +61,7 @@
     <Link>
       <AdditionalDependencies>libopenrct2.lib;libopenrct2ui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)openrct2-win.pdb</ProgramDatabaseFile>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>
       <TargetMachine Condition="'$(Platform)'=='Win32'">MachineX86</TargetMachine>

--- a/src/openrct2/command_line/CommandLine.cpp
+++ b/src/openrct2/command_line/CommandLine.cpp
@@ -529,6 +529,20 @@ namespace OpenRCT2
 {
     int32_t CommandLineRun(const char** argv, int32_t argc)
     {
+        // Check for flags that imply terminal allocation
+        bool forceAllocate = false;
+        for (int32_t i = 1; i < argc; i++)
+        {
+            if (String::equals(argv[i], "--console") || String::equals(argv[i], "-h") || String::equals(argv[i], "--help")
+                || String::equals(argv[i], "-v") || String::equals(argv[i], "--version") || String::equals(argv[i], "-a")
+                || String::equals(argv[i], "--all") || String::equals(argv[i], "--about"))
+            {
+                forceAllocate = true;
+                break;
+            }
+        }
+        Platform::TryAllocateConsole(forceAllocate);
+
         auto argEnumerator = CommandLineArgEnumerator(argv, argc);
 
         // Pop process path

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -51,6 +51,7 @@ namespace OpenRCT2
 
     static bool _help = false;
     static bool _version = false;
+    static bool _console = false;
     static bool _noInstall = false;
     static bool _all = false;
     static bool _about = false;
@@ -69,6 +70,7 @@ namespace OpenRCT2
     {
         { CMDLINE_TYPE_SWITCH,  &_help,             'h', "help",               "show this help message and exit"                            },
         { CMDLINE_TYPE_SWITCH,  &_version,          'v', "version",            "show version information and exit"                          },
+        { CMDLINE_TYPE_SWITCH,  &_console,          kNAC, "console",            "show the console"                                           },
         { CMDLINE_TYPE_SWITCH,  &_noInstall,        'n', "no-install",         "do not install scenario if passed"                          },
         { CMDLINE_TYPE_SWITCH,  &_all,              'a', "all",                "show help for all commands"                                 },
         { CMDLINE_TYPE_SWITCH,  &_about,            kNAC, "about",              "show information about " OPENRCT2_NAME                      },

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -76,6 +76,10 @@ namespace OpenRCT2::Platform
         return false;
     }
 
+    void TryAllocateConsole(bool forceAllocate)
+    {
+    }
+
     uint16_t GetLocaleLanguage()
     {
         JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());

--- a/src/openrct2/platform/Platform.Emscripten.cpp
+++ b/src/openrct2/platform/Platform.Emscripten.cpp
@@ -67,6 +67,10 @@ namespace OpenRCT2::Platform
         return false;
     }
 
+    void TryAllocateConsole(bool forceAllocate)
+    {
+    }
+
     uint16_t GetLocaleLanguage()
     {
         auto locale = reinterpret_cast<char*>(EM_ASM_PTR({

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -221,7 +221,9 @@ namespace OpenRCT2::Platform
     uint64_t GetLastModified(std::string_view path)
     {
         uint64_t lastModified = 0;
-        struct stat statInfo{};
+        struct stat statInfo
+        {
+        };
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             lastModified = statInfo.st_mtime;
@@ -232,7 +234,9 @@ namespace OpenRCT2::Platform
     uint64_t GetFileSize(std::string_view path)
     {
         uint64_t size = 0;
-        struct stat statInfo{};
+        struct stat statInfo
+        {
+        };
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             size = statInfo.st_size;

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -221,9 +221,7 @@ namespace OpenRCT2::Platform
     uint64_t GetLastModified(std::string_view path)
     {
         uint64_t lastModified = 0;
-        struct stat statInfo
-        {
-        };
+        struct stat statInfo{};
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             lastModified = statInfo.st_mtime;
@@ -234,9 +232,7 @@ namespace OpenRCT2::Platform
     uint64_t GetFileSize(std::string_view path)
     {
         uint64_t size = 0;
-        struct stat statInfo
-        {
-        };
+        struct stat statInfo{};
         if (stat(std::string(path).c_str(), &statInfo) == 0)
         {
             size = statInfo.st_size;

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -108,6 +108,10 @@ namespace OpenRCT2::Platform
         return isSupported;
     }
 
+    void TryAllocateConsole(bool forceAllocate)
+    {
+    }
+
     bool IsRunningInWine()
     {
         return false;

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -297,6 +297,31 @@ namespace OpenRCT2::Platform
         return isSupported;
     }
 
+    void TryAllocateConsole(bool forceAllocate)
+    {
+        bool attached = false;
+        if (AttachConsole(ATTACH_PARENT_PROCESS))
+        {
+            attached = true;
+        }
+        else if (forceAllocate && AllocConsole())
+        {
+            attached = true;
+        }
+
+        if (attached)
+        {
+            // Redirect stdio to the console
+            FILE* fDummy;
+            freopen_s(&fDummy, "CONIN$", "r", stdin);
+            freopen_s(&fDummy, "CONOUT$", "w", stdout);
+            freopen_s(&fDummy, "CONOUT$", "w", stderr);
+
+            SetConsoleCP(CP_UTF8);
+            SetConsoleOutputCP(CP_UTF8);
+        }
+    }
+
     static std::string WIN32_GetKnownFolderPath(REFKNOWNFOLDERID rfid)
     {
         std::string path;

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -174,6 +174,7 @@ namespace OpenRCT2::Platform
 
     bool IsRunningInWine();
     bool IsColourTerminalSupported();
+    void TryAllocateConsole(bool forceAllocate);
     bool HandleSpecialCommandLineArgument(const char* argument);
     u8string StrDecompToPrecomp(u8string_view input);
     bool RequireNewWindow(bool openGL);


### PR DESCRIPTION
This change consolidates the Windows build into a single `openrct2.exe` binary with the `WINDOWS` subsystem, removing the separate `openrct2.com` console binary. A new `--console` argument has been added to manually allocate a console window, while existing informational flags like `--help`, `--version`, and `--about` also trigger console allocation. Furthermore, the application now automatically attaches to the parent process's console if one exists, ensuring seamless CLI usage without the need for a separate binary. Corresponding build scripts, CI workflows, and the NSIS installer have been updated to reflect these changes.

---
*PR created automatically by Jules for task [13682055372155196713](https://jules.google.com/task/13682055372155196713) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --console command-line flag to show a console window on Windows.

* **Changes**
  * Removed the .com binary variant from Windows builds, archives, and installers.
  * Windows build now targets the GUI subsystem with dynamic console allocation.
  * Updated the verbose shortcut/launcher to run the main executable with console/verbose flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->