### PR TITLE
Fix linenoise deadlock and implement REPL enhancements

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -2039,3 +2039,25 @@ bool InteractiveConsole::IsExecuting()
 {
     return _commandExecuting.test();
 }
+
+std::vector<std::string> InteractiveConsole::GetCommandNames() const
+{
+    std::vector<std::string> names;
+    names.reserve(std::size(console_command_table));
+    for (const auto& c : console_command_table)
+    {
+        names.emplace_back(c.command);
+    }
+    return names;
+}
+
+std::vector<std::string> InteractiveConsole::GetVariableNames() const
+{
+    std::vector<std::string> names;
+    names.reserve(std::size(console_variable_table));
+    for (const auto& v : console_variable_table)
+    {
+        names.emplace_back(v);
+    }
+    return names;
+}

--- a/src/openrct2/interface/InteractiveConsole.h
+++ b/src/openrct2/interface/InteractiveConsole.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 enum class ConsoleInput : uint8_t
 {
@@ -55,6 +56,9 @@ public:
     void EndAsyncExecution();
 
     bool IsExecuting();
+
+    std::vector<std::string> GetCommandNames() const;
+    std::vector<std::string> GetVariableNames() const;
 
     virtual void Clear() = 0;
     virtual void Close() = 0;

--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -19,11 +19,27 @@
 #include <cstdlib>
 #include <linenoise.hpp>
 
+#ifndef _WIN32
+    #include <csignal>
+#endif
+
 using namespace OpenRCT2;
 
 // Ignore isatty warning on WIN32
 #ifdef _MSC_VER
     #pragma warning(disable : 4996)
+#endif
+
+#ifndef _WIN32
+static std::atomic<bool> _terminalNeedsRestoration{ false };
+static void HandleSignal(int32_t signal)
+{
+    if (_terminalNeedsRestoration.exchange(false))
+    {
+        linenoise::linenoiseAtExit();
+    }
+    std::raise(signal);
+}
 #endif
 
 void StdInOutConsole::Start()
@@ -40,9 +56,53 @@ void StdInOutConsole::Start()
         return;
     }
 
+#ifndef _WIN32
+    struct sigaction sa
+    {
+    };
+    sa.sa_handler = HandleSignal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;
+    sigaction(SIGINT, &sa, nullptr);
+    sigaction(SIGTERM, &sa, nullptr);
+    sigaction(SIGHUP, &sa, nullptr);
+    sigaction(SIGQUIT, &sa, nullptr);
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGILL, &sa, nullptr);
+    sigaction(SIGFPE, &sa, nullptr);
+    sigaction(SIGABRT, &sa, nullptr);
+#endif
+
     std::thread replThread([this]() -> void {
+        _terminalNeedsRestoration = true;
         linenoise::SetMultiLine(true);
         linenoise::SetHistoryMaxLen(32);
+
+        linenoise::SetCompletionCallback([this](const char* buf, std::vector<std::string>& completions) {
+            std::string input(buf);
+            auto commands = GetCommandNames();
+            for (const auto& cmd : commands)
+            {
+                if (cmd.find(input) == 0)
+                {
+                    completions.push_back(cmd);
+                }
+            }
+
+            if (input.find("get ") == 0 || input.find("set ") == 0)
+            {
+                std::string prefix = input.substr(0, 4);
+                std::string varPart = input.substr(4);
+                auto variables = GetVariableNames();
+                for (const auto& var : variables)
+                {
+                    if (var.find(varPart) == 0)
+                    {
+                        completions.push_back(prefix + var);
+                    }
+                }
+            }
+        });
 
         std::string prompt = "\033[32mopenrct2 $\x1b[0m ";
         bool lastPromptQuit = false;
@@ -53,6 +113,7 @@ void StdInOutConsole::Start()
             _isPromptShowing = true;
             auto quit = linenoise::Readline(left.c_str(), line);
             _isPromptShowing = false;
+            _terminalNeedsRestoration = false;
             if (quit)
             {
                 if (lastPromptQuit)

--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -36,6 +36,7 @@ static void HandleSignal(int32_t signal)
 {
     if (_terminalNeedsRestoration.exchange(false))
     {
+        // Note: linenoiseAtExit is not strictly async-signal-safe, but common for terminal apps
         linenoise::linenoiseAtExit();
     }
     std::raise(signal);
@@ -57,9 +58,7 @@ void StdInOutConsole::Start()
     }
 
 #ifndef _WIN32
-    struct sigaction sa
-    {
-    };
+    struct sigaction sa{};
     sa.sa_handler = HandleSignal;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESETHAND;
@@ -74,14 +73,15 @@ void StdInOutConsole::Start()
 #endif
 
     std::thread replThread([this]() -> void {
-        _terminalNeedsRestoration = true;
         linenoise::SetMultiLine(true);
         linenoise::SetHistoryMaxLen(32);
 
+        _commands = GetCommandNames();
+        _variables = GetVariableNames();
+
         linenoise::SetCompletionCallback([this](const char* buf, std::vector<std::string>& completions) {
             std::string input(buf);
-            auto commands = GetCommandNames();
-            for (const auto& cmd : commands)
+            for (const auto& cmd : _commands)
             {
                 if (cmd.find(input) == 0)
                 {
@@ -93,8 +93,7 @@ void StdInOutConsole::Start()
             {
                 std::string prefix = input.substr(0, 4);
                 std::string varPart = input.substr(4);
-                auto variables = GetVariableNames();
-                for (const auto& var : variables)
+                for (const auto& var : _variables)
                 {
                     if (var.find(varPart) == 0)
                     {
@@ -111,9 +110,14 @@ void StdInOutConsole::Start()
             std::string line;
             std::string left = prompt;
             _isPromptShowing = true;
+#ifndef _WIN32
+            _terminalNeedsRestoration = true;
+#endif
             auto quit = linenoise::Readline(left.c_str(), line);
-            _isPromptShowing = false;
+#ifndef _WIN32
             _terminalNeedsRestoration = false;
+#endif
+            _isPromptShowing = false;
             if (quit)
             {
                 if (lastPromptQuit)

--- a/src/openrct2/interface/StdInOutConsole.cpp
+++ b/src/openrct2/interface/StdInOutConsole.cpp
@@ -16,12 +16,10 @@
 #include "../platform/Platform.h"
 #include "../scripting/ScriptEngine.h"
 
+#include <atomic>
+#include <csignal>
 #include <cstdlib>
 #include <linenoise.hpp>
-
-#ifndef _WIN32
-    #include <csignal>
-#endif
 
 using namespace OpenRCT2;
 
@@ -31,11 +29,12 @@ using namespace OpenRCT2;
 #endif
 
 #ifndef _WIN32
-static std::atomic<bool> _terminalNeedsRestoration{ false };
-static void HandleSignal(int32_t signal)
+static volatile sig_atomic_t _terminalNeedsRestoration = 0;
+static void HandleSignal(int signal)
 {
-    if (_terminalNeedsRestoration.exchange(false))
+    if (_terminalNeedsRestoration)
     {
+        _terminalNeedsRestoration = 0;
         // Note: linenoiseAtExit is not strictly async-signal-safe, but common for terminal apps
         linenoise::linenoiseAtExit();
     }
@@ -111,11 +110,11 @@ void StdInOutConsole::Start()
             std::string left = prompt;
             _isPromptShowing = true;
 #ifndef _WIN32
-            _terminalNeedsRestoration = true;
+            _terminalNeedsRestoration = 1;
 #endif
             auto quit = linenoise::Readline(left.c_str(), line);
 #ifndef _WIN32
-            _terminalNeedsRestoration = false;
+            _terminalNeedsRestoration = 0;
 #endif
             _isPromptShowing = false;
             if (quit)

--- a/src/openrct2/interface/StdInOutConsole.h
+++ b/src/openrct2/interface/StdInOutConsole.h
@@ -20,6 +20,8 @@ class StdInOutConsole final : public InteractiveConsole
 private:
     std::queue<std::tuple<std::promise<void>, std::string>> _evalQueue;
     std::atomic<bool> _isPromptShowing{};
+    std::vector<std::string> _commands;
+    std::vector<std::string> _variables;
 
 public:
     void Start();

--- a/src/thirdparty/linenoise.hpp
+++ b/src/thirdparty/linenoise.hpp
@@ -1768,12 +1768,14 @@ inline void linenoiseBeep(void) {
  *
  * The state of the editing is encapsulated into the pointed linenoiseState
  * structure as described in the structure definition. */
-inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
+inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c, std::unique_lock<std::mutex>& lock) {
     std::vector<std::string> lc;
     int nread = 0, nwritten;
     *c = 0;
 
+    lock.unlock();
     completionCallback(ls->buf,lc);
+    lock.lock();
     if (lc.empty()) {
         linenoiseBeep();
     } else {
@@ -1795,7 +1797,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
             }
 
             //nread = read(ls->ifd,&c,1);
-            lnstate_mutex.unlock();
+            lock.unlock();
 #ifdef _WIN32
             nread = win32read(c);
             if (nread == 1) {
@@ -1804,7 +1806,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
 #else
             nread = unicodeReadUTF8Char(ls->ifd,cbuf,c);
 #endif
-            lnstate_mutex.lock();
+            lock.lock();
             if (nread <= 0) {
                 *c = -1;
                 return nread;
@@ -2110,7 +2112,7 @@ inline void linenoiseEditRefreshLine()
  * The function returns the length of the current buffer. */
 inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, const char *prompt)
 {
-    std::lock_guard lock(lnstate_mutex);
+    std::unique_lock lock(lnstate_mutex);
     auto& l = lnstate;
 
     /* Populate the linenoise state that we pass to functions implementing
@@ -2145,7 +2147,7 @@ inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, con
         [[maybe_unused]] auto ifd = l.ifd;
 
         // Release the lock such that others can still write while we await input
-        lnstate_mutex.unlock();
+        lock.unlock();
 #ifdef _WIN32
         nread = win32read(&c);
         if (nread == 1) {
@@ -2155,14 +2157,14 @@ inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, con
         nread = unicodeReadUTF8Char(ifd,cbuf,&c);
 #endif
         // Take back ownership of the lock, since we are going to modify the state now
-        lnstate_mutex.lock();
+        lock.lock();
         if (nread <= 0) return (int)l.len;
 
         /* Only autocomplete when the callback is set. It returns < 0 when
          * there was an error reading from fd. Otherwise it will return the
          * character that should be handled next. */
         if (c == 9 && completionCallback != NULL) {
-            nread = completeLine(&l,cbuf,&c);
+            nread = completeLine(&l,cbuf,&c,lock);
             /* Return on errors */
             if (c < 0) return l.len;
             /* Read next character when 0 */
@@ -2215,27 +2217,27 @@ inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, con
             /* Read the next two bytes representing the escape sequence.
              * Use two calls to handle slow terminals returning the two
              * chars at different times. */
-            lnstate_mutex.unlock();
+            lock.unlock();
             if (read(l.ifd,seq,1) == -1) {
-                lnstate_mutex.lock();
+                lock.lock();
                 break;
             }
             if (read(l.ifd,seq+1,1) == -1) {
-                lnstate_mutex.lock();
+                lock.lock();
                 break;
             }
-            lnstate_mutex.lock();
+            lock.lock();
 
             /* ESC [ sequences. */
             if (seq[0] == '[') {
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional byte. */
-                    lnstate_mutex.unlock();
+                    lock.unlock();
                     if (read(l.ifd,seq+2,1) == -1) {
-                        lnstate_mutex.lock();
+                        lock.lock();
                         break;
                     }
-                    lnstate_mutex.lock();
+                    lock.lock();
                     if (seq[2] == '~') {
                         switch(seq[1]) {
                         case '3': /* Delete key. */

--- a/src/thirdparty/linenoise.hpp
+++ b/src/thirdparty/linenoise.hpp
@@ -2098,7 +2098,7 @@ inline void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
 
 inline void linenoiseEditRefreshLine()
 {
-    std::lock_guard lock(lnstate_mutex);
+    std::lock_guard<std::mutex> lock(lnstate_mutex);
     refreshLine(&lnstate);
 }
 
@@ -2112,7 +2112,7 @@ inline void linenoiseEditRefreshLine()
  * The function returns the length of the current buffer. */
 inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, const char *prompt)
 {
-    std::unique_lock lock(lnstate_mutex);
+    std::unique_lock<std::mutex> lock(lnstate_mutex);
     auto& l = lnstate;
 
     /* Populate the linenoise state that we pass to functions implementing

--- a/src/thirdparty/linenoise.hpp
+++ b/src/thirdparty/linenoise.hpp
@@ -1795,6 +1795,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
             }
 
             //nread = read(ls->ifd,&c,1);
+            lnstate_mutex.unlock();
 #ifdef _WIN32
             nread = win32read(c);
             if (nread == 1) {
@@ -1803,6 +1804,7 @@ inline int completeLine(struct linenoiseState *ls, char *cbuf, int *c) {
 #else
             nread = unicodeReadUTF8Char(ls->ifd,cbuf,c);
 #endif
+            lnstate_mutex.lock();
             if (nread <= 0) {
                 *c = -1;
                 return nread;
@@ -2213,14 +2215,27 @@ inline int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, int buflen, con
             /* Read the next two bytes representing the escape sequence.
              * Use two calls to handle slow terminals returning the two
              * chars at different times. */
-            if (read(l.ifd,seq,1) == -1) break;
-            if (read(l.ifd,seq+1,1) == -1) break;
+            lnstate_mutex.unlock();
+            if (read(l.ifd,seq,1) == -1) {
+                lnstate_mutex.lock();
+                break;
+            }
+            if (read(l.ifd,seq+1,1) == -1) {
+                lnstate_mutex.lock();
+                break;
+            }
+            lnstate_mutex.lock();
 
             /* ESC [ sequences. */
             if (seq[0] == '[') {
                 if (seq[1] >= '0' && seq[1] <= '9') {
                     /* Extended escape, read additional byte. */
-                    if (read(l.ifd,seq+2,1) == -1) break;
+                    lnstate_mutex.unlock();
+                    if (read(l.ifd,seq+2,1) == -1) {
+                        lnstate_mutex.lock();
+                        break;
+                    }
+                    lnstate_mutex.lock();
                     if (seq[2] == '~') {
                         switch(seq[1]) {
                         case '3': /* Delete key. */


### PR DESCRIPTION
This PR addresses a deadlock in the interactive console where background log messages would hang if the user was interacting with the console. It also enhances the console experience by adding tab completion for commands and variables, and ensures that the terminal is correctly restored on Linux even if the process crashes or is terminated.

---
*PR created automatically by Jules for task [17358246187220783879](https://jules.google.com/task/17358246187220783879) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console now exposes lists of available commands and variables for completion.

* **Improvements**
  * Auto-completion offers command suggestions and context-aware "get"/"set" variable suggestions.
  * Better signal handling on non-Windows builds for cleaner shutdown behavior.
  * More robust locking around console I/O for improved stability and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->