### PR TITLE
Zipped assets for desktop platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
       - name: Build graphics .dat files
         run: |
           OpenRCT2/scripts/build-graphics-dat "$PWD"
+      - name: Build bundled assets
+        run: |
+          # We need to build openrct2-cli first to use it for bundling
+          # Or we can just use the zip tool if available
+          zip -r0 data.zip g2.dat palettes.dat fonts.dat tracks.dat OpenRCT2/data/
       - name: Upload graphics .dat files
         uses: actions/upload-artifact@v6
         with:
@@ -186,6 +191,7 @@ jobs:
             palettes.dat
             fonts.dat
             tracks.dat
+            data.zip
   windows:
     name: Windows
     runs-on: ${{ matrix.runs_on }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ option(ENABLE_ASAN "Enable the AddressSanitizer.")
 option(ENABLE_UBSAN "Enable the UndefinedBehaviourSanitizer.")
 option(ENABLE_HEADERS_CHECK "Check if include directives in header files are correct. Only works with clang" OFF)
 option(DISABLE_GUI "Don't build GUI. (Headless only.)")
+option(BUNDLE_ASSETS "Bundle assets into data.zip for desktop platforms" ON)
 
 
 if (FORCE32)
@@ -414,6 +415,21 @@ if (NOT CMAKE_CROSSCOMPILING)
     if(NOT DISABLE_GUI)
         add_dependencies(openrct2 graphics)
     endif()
+
+    if (BUNDLE_ASSETS AND NOT ANDROID)
+        set(asset_zip "${CMAKE_CURRENT_BINARY_DIR}/data.zip")
+        file(GLOB_RECURSE data_files CONFIGURE_DEPENDS "${ROOT_DIR}/data/*")
+        add_custom_command(
+            OUTPUT ${asset_zip}
+            COMMAND ./openrct2-cli asset bundle "${asset_zip}" "${ROOT_DIR}/data" ${output_files}
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+            DEPENDS openrct2-cli graphics ${data_files}
+        )
+        add_custom_target(bundled_assets ALL DEPENDS ${asset_zip})
+        if(NOT DISABLE_GUI)
+            add_dependencies(openrct2 bundled_assets)
+        endif()
+    endif ()
     
 else ()
     message("Skipping graphics generation in cross-compile")
@@ -494,11 +510,15 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
                 SHA256 ${REPLAYS_SHA256}
             )")
     endif ()
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/fonts.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/palettes.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tracks.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
-    install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+    if (BUNDLE_ASSETS AND NOT ANDROID)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/data.zip" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+    else ()
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/g2.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/fonts.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/palettes.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tracks.dat" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+        install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_DATADIR}/openrct2")
+    endif ()
 
     # even when building WITH_TESTS, none of the below install steps are required for OpenRCT2.app
     if (NOT MACOS_BUNDLE)

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -193,8 +193,9 @@ Section "!OpenRCT2" Section1
 
     ; Copy data files. Clear out the old dir first, to ensure upgrades do not result in old objects sticking around.
     RMDir /r "$INSTDIR\data"
-    SetOutPath "$INSTDIR\data\"
-    File /r ${PATH_ROOT}bin\data\*
+    Delete "$INSTDIR\data.zip"
+    SetOutPath "$INSTDIR\"
+    File ${PATH_ROOT}bin\data.zip
 
     ; Copy the rest of the stuff
     SetOutPath "$INSTDIR\"
@@ -302,6 +303,7 @@ Section "Uninstall"
 
     ; Data files
     RMDir /r "$INSTDIR\data"
+    Delete "$INSTDIR\data.zip"
 
     ; Remove remaining directories
     RMDir "$SMPROGRAMS\$SHORTCUTS"

--- a/openrct2.targets
+++ b/openrct2.targets
@@ -184,4 +184,11 @@
            AlwaysCreate="true" />
   </Target>
   <Target Name="palettes" DependsOnTargets="BuildPalettes" />
+
+  <Target Name="BundleAssets"
+          AfterTargets="CopyLanguageFiles;CopyShaders;CopyScenarioPatches;BuildG2;BuildFonts;BuildTracks;BuildPalettes"
+          Condition="'$(BUNDLE_ASSETS)' != 'false'">
+    <Exec Command="&quot;$(GraphicsCLIPath)&quot; asset bundle &quot;$(OutDir)data.zip&quot; &quot;$(DataOutputPath)&quot; &quot;$(DataOutputPath)g2.dat&quot; &quot;$(DataOutputPath)fonts.dat&quot; &quot;$(DataOutputPath)tracks.dat&quot; &quot;$(DataOutputPath)palettes.dat&quot;"
+          IgnoreExitCode="false" />
+  </Target>
 </Project>

--- a/scripts/build-portable
+++ b/scripts/build-portable
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
         rm $destination
     fi
     7z a -r $destination \
-        openrct2.exe openrct2.com data \
+        openrct2.exe openrct2.com data.zip \
         ../contributors.md \
         ../PRIVACY.md \
         ../licence.txt \
@@ -60,7 +60,11 @@ else
         cp -R $install/lib/ $workdir/OpenRCT2
     fi
     cp -r $install/share/doc/openrct2 $workdir/OpenRCT2/doc
-    cp -r $install/share/openrct2 $workdir/OpenRCT2/data
+    if [[ -f $install/share/openrct2/data.zip ]]; then
+        cp $install/share/openrct2/data.zip $workdir/OpenRCT2/
+    else
+        cp -r $install/share/openrct2 $workdir/OpenRCT2/data
+    fi
     pushd $workdir > /dev/null
         tar -czf output.tar.gz OpenRCT2
     popd > /dev/null

--- a/scripts/bundle-assets
+++ b/scripts/bundle-assets
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Bundles assets into data.zip for desktop platforms
+
+BIN_DIR="$1"
+if [ -z "$BIN_DIR" ]; then
+    echo "Usage: $0 <bin directory>"
+    exit 1
+fi
+
+echo "Bundling assets in $BIN_DIR"
+
+cd "$BIN_DIR" || exit 1
+
+# If we have openrct2-cli, use it. Otherwise use zip.
+if [ -f "./openrct2-cli" ]; then
+    ./openrct2-cli asset bundle data.zip data g2.dat palettes.dat fonts.dat tracks.dat
+else
+    # Fallback to standard zip tool if openrct2-cli is not yet built (e.g. in g2dat job)
+    # Note: Ensure the layout is correct (no 'data/' prefix for top level files, but 'data/' prefix for others?)
+    # Wait, the ZIP provider expects everything relative to the install path.
+    # So g2.dat should be at root, and language files should be at data/language/...
+    # My current asset bundle command puts everything relative to dataDir into data/... but wait
+
+    # Actually, my updated asset bundle command puts dataFiles->GetPathRelative() into the ZIP.
+    # So if dataDir is "data", then "language/en-GB.txt" goes to "language/en-GB.txt" in ZIP.
+
+    zip -r0 data.zip g2.dat palettes.dat fonts.dat tracks.dat
+    if [ -d "data" ]; then
+        cd data
+        zip -r0 ../data.zip .
+        cd ..
+    fi
+fi
+
+echo "Bundled assets into $BIN_DIR/data.zip"

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -28,7 +28,10 @@ set(LIBOPENRCT2_LINKAGE)
 if (APPLE)
   set(LIBOPENRCT2_LINKAGE STATIC)
 endif()
-add_library(libopenrct2 ${LIBOPENRCT2_LINKAGE} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${OPENRCT2_DUKTAPE_SOURCES})
+add_library(libopenrct2 ${LIBOPENRCT2_LINKAGE} ${OPENRCT2_CORE_SOURCES} ${OPENRCT2_CORE_MM_SOURCES} ${OPENRCT2_DUKTAPE_SOURCES}
+    "${CMAKE_CURRENT_LIST_DIR}/command_line/AssetCommands.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/platform/ZipAssetProvider.cpp"
+)
 add_library(OpenRCT2::libopenrct2 ALIAS libopenrct2)
 
 if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
@@ -296,6 +299,7 @@ endif ()
 if (UNIX)
     add_definitions(-D_FILE_OFFSET_BITS=64)
 endif ()
+
 
 # Defines
 target_compile_definitions(libopenrct2 PUBLIC

--- a/src/openrct2/command_line/AssetCommands.cpp
+++ b/src/openrct2/command_line/AssetCommands.cpp
@@ -1,0 +1,89 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "CommandLine.hpp"
+
+#include "../core/Console.hpp"
+#include "../core/File.h"
+#include "../core/FileScanner.h"
+#include "../core/Path.hpp"
+#include "../core/String.hpp"
+#include "../core/FileSystem.hpp"
+#include "../core/Zip.h"
+
+#ifndef __ANDROID__
+    #include <zip.h>
+#endif
+#include <string>
+#include <vector>
+
+namespace OpenRCT2
+{
+    exitcode_t HandleAssetBundle(CommandLineArgEnumerator* enumerator)
+    {
+        const char* zipPath;
+        if (!enumerator->TryPopString(&zipPath))
+        {
+            Console::Error::WriteLine("Expected zip path.");
+            return EXITCODE_FAIL;
+        }
+
+        const char* dataDir;
+        if (!enumerator->TryPopString(&dataDir))
+        {
+            Console::Error::WriteLine("Expected data directory.");
+            return EXITCODE_FAIL;
+        }
+
+        std::vector<std::string> additionalFiles;
+        const char* extraFile;
+        while (enumerator->TryPopString(&extraFile))
+        {
+            additionalFiles.push_back(extraFile);
+        }
+
+        try
+        {
+            auto archive = Zip::Open(zipPath, ZipAccess::write);
+
+            // Add files from data directory
+            auto pattern = Path::Combine(dataDir, u8"*");
+            auto dataFiles = Path::ScanDirectory(pattern, true);
+            while (dataFiles->Next())
+            {
+                auto fullPath = dataFiles->GetPath();
+                auto relativePath = dataFiles->GetPathRelative();
+                auto data = File::ReadAllBytes(fullPath);
+                archive->SetFileData(relativePath, std::move(data));
+                archive->SetFileCompression(relativePath, ZIP_CM_STORE);
+            }
+
+            // Add additional files (usually .dat files)
+            for (const auto& file : additionalFiles)
+            {
+                auto data = File::ReadAllBytes(file);
+                auto filename = Path::GetFileName(file);
+                archive->SetFileData(filename, std::move(data));
+                archive->SetFileCompression(filename, ZIP_CM_STORE);
+            }
+
+            // Important: ZipArchive destructor calls zip_close which actually writes the file.
+            archive.reset();
+
+            Console::WriteLine("Successfully bundled assets into %s", zipPath);
+            return EXITCODE_OK;
+        }
+        catch (const std::exception& e)
+        {
+            Console::Error::WriteLine("Failed to bundle assets: %s", e.what());
+            return EXITCODE_FAIL;
+        }
+    }
+
+} // namespace OpenRCT2

--- a/src/openrct2/command_line/CommandLine.hpp
+++ b/src/openrct2/command_line/CommandLine.hpp
@@ -118,6 +118,7 @@ namespace OpenRCT2
         }
         extern const CommandLineCommand kSimulateCommands[];
         extern const CommandLineCommand kParkInfoCommands[];
+        extern const CommandLineCommand kAssetCommands[];
 
         extern const CommandLineExample kRootExamples[];
 
@@ -127,4 +128,6 @@ namespace OpenRCT2
         exitcode_t HandleCommandUri(CommandLineArgEnumerator* enumerator);
         exitcode_t HandleCommandTriggerSteamDownload(CommandLineArgEnumerator* enumerator);
     } // namespace CommandLine
+
+    exitcode_t HandleAssetBundle(CommandLineArgEnumerator* enumerator);
 } // namespace OpenRCT2

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -117,6 +117,11 @@ namespace OpenRCT2
     static void PrintVersion();
     static void PrintLaunchInformation();
 
+    const CommandLineCommand CommandLine::kAssetCommands[] = {
+        DefineCommand("bundle", "<zip path> <data dir> [extra files...]", nullptr, HandleAssetBundle),
+        kCommandTableEnd
+    };
+
     const CommandLineCommand CommandLine::kRootCommands[]
     {
         // Main commands
@@ -147,6 +152,7 @@ namespace OpenRCT2
         DefineSubCommand("sprite",          Sprite::kSpriteCommands   ),
         DefineSubCommand("simulate",        kSimulateCommands         ),
         DefineSubCommand("parkinfo",        kParkInfoCommands         ),
+        DefineSubCommand("asset",           kAssetCommands            ),
         kCommandTableEnd
     };
 

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -253,20 +253,19 @@ private:
 
 #endif // _WIN32
 
-#ifdef __ANDROID__
-
-class FileScannerAndroidAssets final : public FileScannerBase
+class FileScannerAssets final : public FileScannerBase
 {
 public:
-    FileScannerAndroidAssets(u8string_view pattern, bool recurse)
+    FileScannerAssets(u8string_view pattern, bool recurse, u8string_view root)
         : FileScannerBase(pattern, recurse)
+        , _root(root)
     {
     }
 
     void GetDirectoryChildren(std::vector<DirectoryChild>& children, const std::string& path) override
     {
         const auto& assetList = Platform::GetAssetList();
-        std::string prefix = path.substr(Platform::kAndroidAssetPathPrefix.length());
+        std::string prefix = path.substr(_root.length());
         if (!prefix.empty() && prefix.back() != '/')
         {
             prefix += '/';
@@ -307,8 +306,10 @@ public:
             }
         }
     }
+
+private:
+    u8string _root;
 };
-#endif // __ANDROID__
 
 #if defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))
 
@@ -390,9 +391,15 @@ std::unique_ptr<IFileScanner> Path::ScanDirectory(const std::string& pattern, bo
 #ifdef __ANDROID__
     if (String::startsWith(pattern, Platform::kAndroidAssetPathPrefix))
     {
-        return std::make_unique<FileScannerAndroidAssets>(pattern, recurse);
+        return std::make_unique<FileScannerAssets>(pattern, recurse, Platform::kAndroidAssetPathPrefix);
     }
 #endif
+
+    auto installPath = Platform::GetInstallPath();
+    if (String::startsWith(pattern, installPath) && !Path::DirectoryExists(installPath))
+    {
+        return std::make_unique<FileScannerAssets>(pattern, recurse, installPath);
+    }
 #ifdef _WIN32
     return std::make_unique<FileScannerWindows>(pattern, recurse);
 #elif defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -9,6 +9,7 @@
 
 #include "Zip.h"
 
+#include "../Diagnostic.h"
 #include "IStream.hpp"
 
 #ifndef __ANDROID__
@@ -79,7 +80,7 @@ public:
         auto zipOpenMode = ZIP_RDONLY;
         if (access == ZipAccess::write)
         {
-            zipOpenMode = ZIP_CREATE;
+            zipOpenMode = ZIP_CREATE | ZIP_TRUNCATE;
         }
 
         int32_t error;
@@ -94,7 +95,10 @@ public:
 
     ~ZipArchive() override
     {
-        zip_close(_zip);
+        if (zip_close(_zip) == -1)
+        {
+            LOG_ERROR("Failed to close zip archive: %s", zip_strerror(_zip));
+        }
     }
 
     size_t GetNumFiles() const override
@@ -181,6 +185,18 @@ public:
         {
             zip_source_free(source);
             throw std::runtime_error(std::string(zip_strerror(_zip)));
+        }
+    }
+
+    void SetFileCompression(std::string_view path, int32_t method, int32_t level) override
+    {
+        auto index = GetIndexFromPath(path);
+        if (index.has_value())
+        {
+            if (zip_set_file_compression(_zip, index.value(), method, static_cast<zip_uint32_t>(level)) == -1)
+            {
+                throw std::runtime_error(std::string(zip_strerror(_zip)));
+            }
         }
     }
 

--- a/src/openrct2/core/Zip.h
+++ b/src/openrct2/core/Zip.h
@@ -43,6 +43,11 @@ struct IZipArchive
      */
     virtual void SetFileData(std::string_view path, std::vector<uint8_t>&& data) = 0;
 
+    /**
+     * Sets the compression method for a file in the zip archive.
+     */
+    virtual void SetFileCompression(std::string_view path, int32_t method, int32_t level = 0) = 0;
+
     virtual void DeleteFile(std::string_view path) = 0;
     virtual void RenameFile(std::string_view path, std::string_view newPath) = 0;
 

--- a/src/openrct2/platform/AssetTypes.h
+++ b/src/openrct2/platform/AssetTypes.h
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../core/StringTypes.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace OpenRCT2
+{
+    namespace Platform
+    {
+        enum class AssetCheckResult
+        {
+            NotApplicable,
+            Found,
+            NotFound,
+        };
+
+        using AssetHandle = void*;
+
+        struct AssetFileOpenResult
+        {
+            AssetCheckResult result;
+            AssetHandle handle;
+            uint64_t size;
+        };
+    }
+
+    struct AssetInfo
+    {
+        std::string Path;
+        uint64_t Size;
+    };
+} // namespace OpenRCT2

--- a/src/openrct2/platform/IAssetProvider.h
+++ b/src/openrct2/platform/IAssetProvider.h
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "AssetTypes.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace OpenRCT2
+{
+    /**
+     * Provides access to bundled assets (e.g. Android assets, ZIP archives).
+     */
+    struct IAssetProvider
+    {
+        virtual ~IAssetProvider() = default;
+
+        /**
+         * Checks if an asset exists at the given path.
+         */
+        virtual OpenRCT2::Platform::AssetCheckResult CheckAssetExists(u8string_view path) = 0;
+
+        /**
+         * Checks if a directory exists at the given path.
+         */
+        virtual OpenRCT2::Platform::AssetCheckResult CheckAssetDirectoryExists(u8string_view path) = 0;
+
+        /**
+         * Opens an asset for reading.
+         */
+        virtual OpenRCT2::Platform::AssetFileOpenResult OpenAssetFile(u8string_view path) = 0;
+
+        /**
+         * Closes an asset opened with OpenAssetFile.
+         */
+        virtual void CloseAssetFile(OpenRCT2::Platform::AssetHandle handle) = 0;
+
+        /**
+         * Gets the current position in an opened asset.
+         */
+        virtual uint64_t GetAssetPosition(OpenRCT2::Platform::AssetHandle handle) = 0;
+
+        /**
+         * Seeks to a position in an opened asset.
+         */
+        virtual void SeekAsset(OpenRCT2::Platform::AssetHandle handle, int64_t offset, int32_t origin) = 0;
+
+        /**
+         * Reads data from an opened asset.
+         */
+        virtual uint64_t ReadAsset(OpenRCT2::Platform::AssetHandle handle, void* buffer, uint64_t length) = 0;
+
+        /**
+         * Tries to read data from an opened asset.
+         */
+        virtual uint64_t TryReadAsset(OpenRCT2::Platform::AssetHandle handle, void* buffer, uint64_t length) = 0;
+
+        /**
+         * Gets a list of all assets in the provider.
+         */
+        virtual const std::vector<AssetInfo>& GetAssetList() = 0;
+    };
+} // namespace OpenRCT2

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -29,9 +29,12 @@
 #include "../core/CallingConventions.h"
 #include "../core/File.h"
 #include "../core/Path.hpp"
+#include "../core/FileSystem.hpp"
 #include "../core/String.hpp"
 #include "../localisation/Currency.h"
 #include "Platform.h"
+#include "IAssetProvider.h"
+#include "ZipAssetProvider.h"
 
 #include <algorithm>
 #include <array>
@@ -92,47 +95,162 @@ namespace OpenRCT2::Platform
     }
 
 #ifndef __ANDROID__
-    AssetCheckResult CheckAssetDirectoryExists([[maybe_unused]] u8string_view path)
+    static std::unique_ptr<IAssetProvider> _assetProvider;
+
+    static void EnsureAssetProvider()
     {
+        if (_assetProvider == nullptr)
+        {
+            auto exeDir = GetCurrentExecutableDirectory();
+            auto zipPath = Path::Combine(exeDir, u8"data.zip");
+
+            std::error_code ec;
+            if (fs::exists(fs::u8path(zipPath), ec))
+            {
+                _assetProvider = CreateZipAssetProvider(zipPath);
+            }
+        }
+    }
+
+    static u8string_view GetBundledAssetPath(u8string_view path)
+    {
+        auto installPath = GetInstallPath();
+        // If installPath is the ZIP file itself, it won't be a directory.
+        // We only want to handle paths that are relative to the install path.
+        if (String::startsWith(path, installPath))
+        {
+            auto relative = path.substr(installPath.length());
+            if (!relative.empty() && relative[0] == '/')
+            {
+                return relative.substr(1);
+            }
+            return relative;
+        }
+        return {};
+    }
+
+    AssetCheckResult CheckAssetDirectoryExists(u8string_view path)
+    {
+        // Precedence: directory first. Since File::Exists already handles the directory check
+        // before calling this, we just need to make sure we don't interfere if it's a real directory.
+        // Wait, File::Exists calls Platform::CheckAssetExists FIRST.
+        // So we MUST check if the physical path exists as a directory first.
+        if (Path::DirectoryExists(path))
+        {
+            return AssetCheckResult::NotApplicable;
+        }
+
+        EnsureAssetProvider();
+        if (_assetProvider != nullptr)
+        {
+            auto bundledPath = GetBundledAssetPath(path);
+            if (!bundledPath.empty())
+            {
+                return _assetProvider->CheckAssetDirectoryExists(bundledPath);
+            }
+        }
         return AssetCheckResult::NotApplicable;
     }
 
-    AssetCheckResult CheckAssetExists([[maybe_unused]] u8string_view path)
+    AssetCheckResult CheckAssetExists(u8string_view path)
     {
+        // Precedence: directory first. Check physical file system.
+        std::error_code ec;
+        if (fs::exists(fs::u8path(path), ec))
+        {
+            return AssetCheckResult::NotApplicable;
+        }
+
+        EnsureAssetProvider();
+        if (_assetProvider != nullptr)
+        {
+            auto bundledPath = GetBundledAssetPath(path);
+            if (!bundledPath.empty())
+            {
+                return _assetProvider->CheckAssetExists(bundledPath);
+            }
+        }
         return AssetCheckResult::NotApplicable;
     }
 
-    AssetFileOpenResult OpenAssetFile([[maybe_unused]] u8string_view path)
+    AssetFileOpenResult OpenAssetFile(u8string_view path)
     {
+        // Precedence: directory first. Check physical file system.
+        std::error_code ec;
+        if (fs::exists(fs::u8path(path), ec))
+        {
+            return AssetFileOpenResult{ AssetCheckResult::NotApplicable, nullptr, 0 };
+        }
+
+        EnsureAssetProvider();
+        if (_assetProvider != nullptr)
+        {
+            auto bundledPath = GetBundledAssetPath(path);
+            if (!bundledPath.empty())
+            {
+                return _assetProvider->OpenAssetFile(bundledPath);
+            }
+        }
         return AssetFileOpenResult{ AssetCheckResult::NotApplicable, nullptr, 0 };
     }
 
-    void CloseAssetFile([[maybe_unused]] void* handle)
+    void CloseAssetFile(AssetHandle handle)
     {
+        if (_assetProvider != nullptr)
+        {
+            _assetProvider->CloseAssetFile(handle);
+        }
     }
 
-    uint64_t GetAssetPosition([[maybe_unused]] void* handle)
+    uint64_t GetAssetPosition(AssetHandle handle)
     {
+        if (_assetProvider != nullptr)
+        {
+            return _assetProvider->GetAssetPosition(handle);
+        }
         return 0;
     }
 
-    void SeekAsset([[maybe_unused]] void* handle, [[maybe_unused]] int64_t offset, [[maybe_unused]] int32_t origin)
+    void SeekAsset(AssetHandle handle, int64_t offset, int32_t origin)
     {
+        if (_assetProvider != nullptr)
+        {
+            _assetProvider->SeekAsset(handle, offset, origin);
+        }
     }
 
-    uint64_t ReadAsset([[maybe_unused]] void* handle, [[maybe_unused]] void* buffer, [[maybe_unused]] uint64_t length)
+    uint64_t ReadAsset(AssetHandle handle, void* buffer, uint64_t length)
     {
+        if (_assetProvider != nullptr)
+        {
+            return _assetProvider->ReadAsset(handle, buffer, length);
+        }
         return 0;
     }
 
-    uint64_t TryReadAsset([[maybe_unused]] void* handle, [[maybe_unused]] void* buffer, [[maybe_unused]] uint64_t length)
+    uint64_t TryReadAsset(AssetHandle handle, void* buffer, uint64_t length)
     {
+        if (_assetProvider != nullptr)
+        {
+            return _assetProvider->TryReadAsset(handle, buffer, length);
+        }
         return 0;
     }
 
     u8string GetAssetPath()
     {
         return {};
+    }
+
+    const std::vector<AssetInfo>& GetAssetList()
+    {
+        static const std::vector<AssetInfo> empty;
+        EnsureAssetProvider();
+        if (_assetProvider != nullptr)
+        {
+            return _assetProvider->GetAssetList();
+        }
+        return empty;
     }
 #endif
 

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -43,6 +43,13 @@ namespace OpenRCT2::Platform
         return String::toStd(getenv(std::string(name).c_str()));
     }
 
+    std::string GetCurrentExecutableDirectory()
+    {
+        auto exePath = GetCurrentExecutablePath();
+        auto exeDirectory = Path::GetDirectory(exePath);
+        return exeDirectory;
+    }
+
     std::string GetEnvironmentPath(const char* name)
     {
         auto value = getenv(name);

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -12,6 +12,7 @@
 #include "../config/ConfigTypes.h"
 #include "../core/DateTime.h"
 #include "../core/StringTypes.h"
+#include "AssetTypes.h"
 
 #include <bit>
 #include <ctime>
@@ -61,15 +62,6 @@ struct TTFFontDescriptor;
 
 namespace OpenRCT2::Platform
 {
-    enum class AssetCheckResult
-    {
-        NotApplicable,
-        Found,
-        NotFound,
-    };
-
-    using AssetHandle = void*;
-
     struct SteamGameData
     {
         u8string nativeFolder;
@@ -128,19 +120,12 @@ namespace OpenRCT2::Platform
     static_assert(kAndroidAssetPathPrefix.back() == '/', "kAndroidAssetPathPrefix must end with a slash");
 #endif // __ANDROID__
 
-    struct AssetFileOpenResult
-    {
-        AssetCheckResult result;
-        AssetHandle handle;
-        uint64_t size;
-    };
-
     std::string GetEnvironmentVariable(std::string_view name);
     std::string GetFolderPath(SpecialFolder folder);
     std::string GetInstallPath();
     std::string GetDocsPath();
     std::string GetCurrentExecutablePath();
-    std::string GetCurrentExecutableDirectory();
+    [[nodiscard]] std::string GetCurrentExecutableDirectory();
     bool ShouldIgnoreCase();
     bool IsPathSeparator(char c);
     uint64_t GetLastModified(std::string_view path);
@@ -201,15 +186,10 @@ namespace OpenRCT2::Platform
     bool SetupUriProtocol();
 #endif
 #ifdef __ANDROID__
-    struct AssetInfo
-    {
-        std::string Path;
-        uint64_t Size;
-    };
     jclass AndroidFindClass(JNIEnv* env, std::string_view name);
     void* GetAssetManager();
-    const std::vector<AssetInfo>& GetAssetList();
 #endif
+    const std::vector<OpenRCT2::AssetInfo>& GetAssetList();
 
     bool IsRunningInWine();
     bool IsColourTerminalSupported();

--- a/src/openrct2/platform/ZipAssetProvider.cpp
+++ b/src/openrct2/platform/ZipAssetProvider.cpp
@@ -1,0 +1,178 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "ZipAssetProvider.h"
+
+#include "../Diagnostic.h"
+#include "../core/IStream.hpp"
+#include "../core/String.hpp"
+#include "Platform.h"
+
+#include <algorithm>
+#include <mutex>
+#include <set>
+#include <zip.h>
+
+namespace OpenRCT2
+{
+    class ZipAssetProvider final : public IAssetProvider
+    {
+    private:
+        zip_t* _zip;
+        std::vector<AssetInfo> _assetList;
+        std::mutex _mutex;
+
+    public:
+        ZipAssetProvider(const std::string& zipPath)
+        {
+            int32_t error;
+            _zip = zip_open(zipPath.c_str(), ZIP_RDONLY, &error);
+            if (_zip == nullptr)
+            {
+                throw std::runtime_error("Unable to open zip file: " + zipPath);
+            }
+
+            // Build asset list
+            auto numEntries = zip_get_num_entries(_zip, 0);
+            for (zip_int64_t i = 0; i < numEntries; i++)
+            {
+                zip_stat_t st;
+                if (zip_stat_index(_zip, i, 0, &st) == 0)
+                {
+                    AssetInfo info;
+                    info.Path = st.name;
+                    info.Size = st.size;
+                    _assetList.push_back(std::move(info));
+                }
+            }
+
+            std::sort(_assetList.begin(), _assetList.end(), [](const AssetInfo& a, const AssetInfo& b) {
+                return a.Path < b.Path;
+            });
+        }
+
+        ~ZipAssetProvider() override
+        {
+            zip_close(_zip);
+        }
+
+        OpenRCT2::Platform::AssetCheckResult CheckAssetExists(u8string_view path) override
+        {
+            auto assetPath = std::string(path);
+            auto it = std::lower_bound(
+                _assetList.begin(), _assetList.end(), assetPath,
+                [](const AssetInfo& a, const std::string& b) { return a.Path < b; });
+
+            if (it != _assetList.end() && it->Path == assetPath)
+            {
+                return OpenRCT2::Platform::AssetCheckResult::Found;
+            }
+            return OpenRCT2::Platform::AssetCheckResult::NotFound;
+        }
+
+        OpenRCT2::Platform::AssetCheckResult CheckAssetDirectoryExists(u8string_view path) override
+        {
+            std::string prefix = std::string(path);
+            if (!prefix.empty() && prefix.back() != '/')
+            {
+                prefix += '/';
+            }
+
+            auto it = std::lower_bound(
+                _assetList.begin(), _assetList.end(), prefix,
+                [](const AssetInfo& a, const std::string& b) { return a.Path < b; });
+
+            if (it != _assetList.end() && String::startsWith(it->Path, prefix))
+            {
+                return OpenRCT2::Platform::AssetCheckResult::Found;
+            }
+            return OpenRCT2::Platform::AssetCheckResult::NotFound;
+        }
+
+        OpenRCT2::Platform::AssetFileOpenResult OpenAssetFile(u8string_view path) override
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            std::string pathStr(path);
+            auto assetFile = zip_fopen(_zip, pathStr.c_str(), 0);
+            if (assetFile == nullptr)
+            {
+                return { OpenRCT2::Platform::AssetCheckResult::NotFound, nullptr, 0 };
+            }
+
+            zip_stat_t st;
+            zip_stat(_zip, pathStr.c_str(), 0, &st);
+
+            return { OpenRCT2::Platform::AssetCheckResult::Found, assetFile, st.size };
+        }
+
+        void CloseAssetFile(OpenRCT2::Platform::AssetHandle handle) override
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            zip_fclose(static_cast<zip_file_t*>(handle));
+        }
+
+        uint64_t GetAssetPosition(OpenRCT2::Platform::AssetHandle handle) override
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto pos = zip_ftell(static_cast<zip_file_t*>(handle));
+            return pos >= 0 ? static_cast<uint64_t>(pos) : 0;
+        }
+
+        void SeekAsset(OpenRCT2::Platform::AssetHandle handle, int64_t offset, int32_t origin) override
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            int whence;
+            switch (origin)
+            {
+                case STREAM_SEEK_BEGIN:
+                    whence = SEEK_SET;
+                    break;
+                case STREAM_SEEK_CURRENT:
+                    whence = SEEK_CUR;
+                    break;
+                case STREAM_SEEK_END:
+                    whence = SEEK_END;
+                    break;
+                default:
+                    return;
+            }
+            zip_fseek(static_cast<zip_file_t*>(handle), static_cast<zip_int64_t>(offset), whence);
+        }
+
+        uint64_t ReadAsset(OpenRCT2::Platform::AssetHandle handle, void* buffer, uint64_t length) override
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto readBytes = zip_fread(static_cast<zip_file_t*>(handle), buffer, length);
+            return readBytes > 0 ? static_cast<uint64_t>(readBytes) : 0;
+        }
+
+        uint64_t TryReadAsset(OpenRCT2::Platform::AssetHandle handle, void* buffer, uint64_t length) override
+        {
+            return ReadAsset(handle, buffer, length);
+        }
+
+        const std::vector<AssetInfo>& GetAssetList() override
+        {
+            return _assetList;
+        }
+    };
+
+    std::unique_ptr<IAssetProvider> CreateZipAssetProvider(const std::string& zipPath)
+    {
+        try
+        {
+            return std::make_unique<ZipAssetProvider>(zipPath);
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("%s", e.what());
+            return nullptr;
+        }
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/platform/ZipAssetProvider.h
+++ b/src/openrct2/platform/ZipAssetProvider.h
@@ -1,0 +1,23 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "IAssetProvider.h"
+
+#include <memory>
+#include <string>
+
+namespace OpenRCT2
+{
+    /**
+     * Creates an asset provider that reads from a ZIP archive.
+     */
+    std::unique_ptr<IAssetProvider> CreateZipAssetProvider(const std::string& zipPath);
+} // namespace OpenRCT2


### PR DESCRIPTION
Implemented support for zipped assets (`data.zip`) on Windows, Linux, and macOS. This includes a universal `IAssetProvider` interface, a `ZipAssetProvider` implementation, and updates to the platform, file scanner, build systems (CMake/MSBuild), and CI workflows. The implementation ensures that the local `data` directory takes precedence over the ZIP archive.

---
*PR created automatically by Jules for task [4655195132015675647](https://jules.google.com/task/4655195132015675647) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Game assets are now consolidated into a single `data.zip` file instead of multiple individual files, simplifying distribution and installation across Windows, Linux, and macOS platforms.
- Updated the Windows installer and portable package generation to properly handle the new bundled asset format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->