### PR TITLE
Fuzzy search for large dropdowns

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3826,3 +3826,4 @@ STR_7026    :Makes the whole ride visible
 STR_7027    :{MOVE_X}{29}{STRINGID}
 STR_7028    :Quarter Helix up
 STR_7029    :Quarter Helix down
+STR_7030    :No matches found

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -16,6 +16,7 @@
 #include "WindowManager.h"
 #include "drawing/engines/DrawingEngineFactory.hpp"
 #include "input/ShortcutManager.h"
+#include "interface/Dropdown.h"
 #include "interface/InGameConsole.h"
 #include "interface/Theme.h"
 #include "interface/Viewport.h"
@@ -581,7 +582,7 @@ public:
                     _textComposition.HandleMessage(&e);
                     if (InputGetState() == InputState::DropdownActive)
                     {
-                        Windows::WindowDropdownHandleTextInput(e.text.text);
+                        Ui::Windows::WindowDropdownHandleTextInput(e.text.text);
                     }
                     break;
                 default:

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -579,6 +579,10 @@ public:
                     break;
                 case SDL_TEXTINPUT:
                     _textComposition.HandleMessage(&e);
+                    if (InputGetState() == InputState::DropdownActive)
+                    {
+                        Windows::WindowDropdownHandleTextInput(e.text.text);
+                    }
                     break;
                 default:
                 {

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -16,6 +16,7 @@ namespace OpenRCT2
     enum : StringId
     {
         // General
+        STR_NO_MATCHES_FOUND = 7030,
         STR_ADJUST_LARGER_LAND_TIP = 2379,
         STR_ADJUST_SMALLER_LAND_TIP = 2378,
         STR_BROKEN = 3124,

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -389,7 +389,7 @@ void InputManager::process(const InputEvent& e)
 
             if (InputGetState() == InputState::DropdownActive)
             {
-                if (e.state == InputEventState::release)
+                if (e.state == InputEventState::down)
                 {
                     Ui::Windows::WindowDropdownHandleKeyDown(e.button);
                 }

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -385,6 +385,15 @@ void InputManager::process(const InputEvent& e)
             {
                 return;
             }
+
+        if (InputGetState() == InputState::DropdownActive)
+        {
+            if (e.state == InputEventState::release)
+            {
+                Windows::WindowDropdownHandleKeyDown(e.button);
+            }
+            return;
+        }
         }
     }
     shortcutManager.processEvent(e);

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -17,6 +17,7 @@
 #include <openrct2-ui/UiContext.h>
 #include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/input/ShortcutManager.h>
+#include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/InGameConsole.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/windows/Windows.h>
@@ -386,14 +387,14 @@ void InputManager::process(const InputEvent& e)
                 return;
             }
 
-        if (InputGetState() == InputState::DropdownActive)
-        {
-            if (e.state == InputEventState::release)
+            if (InputGetState() == InputState::DropdownActive)
             {
-                Windows::WindowDropdownHandleKeyDown(e.button);
+                if (e.state == InputEventState::release)
+                {
+                    Ui::Windows::WindowDropdownHandleKeyDown(e.button);
+                }
+                return;
             }
-            return;
-        }
         }
     }
     shortcutManager.processEvent(e);

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1464,29 +1464,6 @@ namespace OpenRCT2
             int32_t dropdown_index = DropdownIndexFromPoint(screenCoords, w);
             if (dropdown_index == -1)
             {
-                if (gDropdown.hasTooltips && gDropdown.lastTooltipHover != -1)
-                {
-                    gDropdown.lastTooltipHover = -1;
-                    WindowTooltipClose();
-                }
-                return;
-            }
-
-            if (gDropdown.hasTooltips && gDropdown.lastTooltipHover != dropdown_index)
-            {
-                gDropdown.lastTooltipHover = dropdown_index;
-                WindowTooltipClose();
-
-                WindowTooltipShow(StringWithArgs{ gDropdown.items[dropdown_index].tooltip, {} }, screenCoords);
-            }
-
-            if (dropdown_index < Dropdown::kItemsMaxSize && gDropdown.items[dropdown_index].isDisabled())
-            {
-                return;
-            }
-
-            if (gDropdown.items[dropdown_index].isSeparator())
-            {
                 return;
             }
 

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1389,13 +1389,6 @@ namespace OpenRCT2
                             gTooltipWidget.windowClassification = cursor_w_class;
                             gTooltipWidget.windowNumber = cursor_w_number;
 
-                            if (dropdown_index == -1)
-                            {
-                                if (gDropdown.defaultIndex != -1 && !gDropdown.items[gDropdown.defaultIndex].isDisabled())
-                                {
-                                    dropdown_index = gDropdown.defaultIndex;
-                                }
-                            }
                             cursor_w->onDropdown(cursor_widgetIndex, dropdown_index);
                         }
                     }

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -221,7 +221,7 @@ namespace OpenRCT2::Dropdown
         std::optional<CellDrawFunction> cellDrawFunction;
 
         // Search filtering
-        utf8 searchText[256]{};
+        u8string searchText;
         int32_t numFilteredItems{};
         std::array<int32_t, kItemsMaxSize> filteredItems{};
     };

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -66,6 +66,9 @@ namespace OpenRCT2::Ui::Windows
         Dropdown::CellDrawFunction drawFunction, int32_t numItems, int32_t itemWidth, int32_t itemHeight, int32_t numColumns);
 
     void WindowDropdownClose();
+    void WindowDropdownSelectItem(int32_t index);
+    void WindowDropdownHandleKeyDown(uint32_t key);
+    void WindowDropdownHandleTextInput(std::string_view text);
 
     int32_t DropdownIndexFromPoint(const ScreenCoordsXY& loc, WindowBase* w);
 
@@ -215,6 +218,11 @@ namespace OpenRCT2::Dropdown
         int32_t defaultIndex{};
 
         std::optional<CellDrawFunction> cellDrawFunction;
+
+        // Search filtering
+        utf8 searchText[256]{};
+        int32_t numFilteredItems{};
+        std::array<int32_t, kItemsMaxSize> filteredItems{};
     };
 
     template<int N>

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -213,9 +213,9 @@ namespace OpenRCT2::Dropdown
         int32_t numItems{};
         std::array<Item, kItemsMaxSize> items{};
         bool hasTooltips{};
-        int32_t lastTooltipHover{};
-        int32_t highlightedIndex{};
-        int32_t defaultIndex{};
+        int32_t lastTooltipHover = -1;
+        int32_t highlightedIndex = -1;
+        int32_t defaultIndex = -1;
 
         std::optional<CellDrawFunction> cellDrawFunction;
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -83,10 +83,11 @@ namespace OpenRCT2::Ui::Windows
 
 namespace OpenRCT2::Dropdown
 {
-    enum Flag
+    enum Flag : uint8_t
     {
         CustomHeight = (1 << 6), // never set?
-        StayOpen = (1 << 7)
+        StayOpen = (1 << 7),
+        NoSearch = (1 << 0)
     };
 
     enum class ItemFlag : uint8_t

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -78,7 +78,7 @@ namespace OpenRCT2::Ui::Windows
         void FilterItems()
         {
             gDropdown.numFilteredItems = 0;
-            if (gDropdown.searchText[0] == '\0')
+            if (gDropdown.searchText.empty())
             {
                 for (int32_t i = 0; i < gDropdown.numItems; i++)
                 {
@@ -167,7 +167,6 @@ namespace OpenRCT2::Ui::Windows
             if (!IsSearchable)
                 return;
 
-            String::safeConcat(gDropdown.searchText, text.data(), sizeof(gDropdown.searchText));
             FilterItems();
             UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
             invalidate();
@@ -181,7 +180,6 @@ namespace OpenRCT2::Ui::Windows
                 {
                     if (IsSearchable)
                     {
-                        String::backspace(gDropdown.searchText);
                         FilterItems();
                         UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
                         invalidate();
@@ -361,7 +359,7 @@ namespace OpenRCT2::Ui::Windows
                 const ScreenCoordsXY searchBoxBottomRight = searchBoxTopLeft + ScreenCoordsXY{ width - 5, ItemHeight - 1 };
                 Rectangle::fillInset(rt, { searchBoxTopLeft, searchBoxBottomRight }, colours[0], Rectangle::BorderStyle::inset);
 
-                std::string searchDisplay = std::string(reinterpret_cast<const char*>(gDropdown.searchText));
+                std::string searchDisplay = gDropdown.searchText;
                 if (TextBoxCaretIsFlashed())
                 {
                     searchDisplay += "_";
@@ -374,11 +372,11 @@ namespace OpenRCT2::Ui::Windows
                 yOffset += ItemHeight + 2;
             }
 
-            if (gDropdown.numFilteredItems == 0 && IsSearchable && gDropdown.searchText[0] != '\0')
+            if (gDropdown.numFilteredItems == 0 && IsSearchable && !gDropdown.searchText.empty())
             {
                 ScreenCoordsXY screenCoords = windowPos + ScreenCoordsXY{ 2, yOffset };
-                drawText(
-                    rt, screenCoords + ScreenCoordsXY{ 2, 1 }, STR_NO_MATCHES_FOUND, {},
+                drawTextEllipsised(
+                    rt, screenCoords + ScreenCoordsXY{ 2, 1 }, width - 7, STR_NO_MATCHES_FOUND, {},
                     { { colours[0].colour, { ColourFlag::inset } } });
                 return;
             }
@@ -461,6 +459,11 @@ namespace OpenRCT2::Ui::Windows
             // Initial highlight from default index
             gDropdown.highlightedIndex = gDropdown.defaultIndex;
             FilterItems();
+
+            if (IsSearchable)
+            {
+                ContextStartTextInput(gDropdown.searchText, 255);
+            }
 
             UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
 
@@ -725,6 +728,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::dropdown);
+        ContextStopTextInput();
     }
 
     void WindowDropdownSelectItem(int32_t index)

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -112,9 +112,10 @@ namespace OpenRCT2::Ui::Windows
                     if (IsSearchable)
                         availableHeight -= (ItemHeight + 2);
 
-                    int32_t numAvailableRows = std::max(1, availableHeight / ItemHeight);
-                    NumRows = std::min({ gDropdown.numFilteredItems, numAvailableRows, MaxRowsPerColumn });
+                    int32_t numAvailableRows = std::max(1, availableHeight / std::max(1, ItemHeight));
+                    NumRows = std::max(1, std::min({ gDropdown.numFilteredItems, numAvailableRows, MaxRowsPerColumn }));
                     NumColumns = (gDropdown.numFilteredItems + NumRows - 1) / NumRows;
+                    NumColumns = std::max(1, NumColumns);
                 }
             }
             else
@@ -174,17 +175,17 @@ namespace OpenRCT2::Ui::Windows
 
         void onKeyDown(uint32_t key)
         {
-            if (!IsSearchable)
-                return;
-
             switch (key)
             {
                 case SDLK_BACKSPACE:
                 {
-                    String::backspace(gDropdown.searchText);
-                    FilterItems();
-                    UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
-                    invalidate();
+                    if (IsSearchable)
+                    {
+                        String::backspace(gDropdown.searchText);
+                        FilterItems();
+                        UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
+                        invalidate();
+                    }
                     break;
                 }
                 case SDLK_ESCAPE:
@@ -445,7 +446,8 @@ namespace OpenRCT2::Ui::Windows
             size_t numItems, int32_t itemWidth, int32_t numRowsPerColumn)
         {
             // Set and calculate num items, rows and columns
-            ItemHeight = (txtFlags & Dropdown::Flag::CustomHeight) ? customItemHeight : GetDefaultRowHeight();
+            ItemHeight = std::max<int32_t>(
+                1, (txtFlags & Dropdown::Flag::CustomHeight) ? customItemHeight : GetDefaultRowHeight());
             ItemPadding = (txtFlags & Dropdown::Flag::CustomHeight) ? 0 : GetAdditionalRowPadding();
             ItemWidth = itemWidth;
             BaseScreenPos = screenPos;
@@ -453,7 +455,7 @@ namespace OpenRCT2::Ui::Windows
             MaxRowsPerColumn = numRowsPerColumn > 0 ? numRowsPerColumn : Dropdown::kItemsMaxSize;
 
             gDropdown.numItems = static_cast<int32_t>(numItems);
-            IsSearchable = (gDropdown.numItems > 10);
+            IsSearchable = (gDropdown.numItems > 10) && !(txtFlags & Dropdown::Flag::NoSearch);
             ListVertically = true;
 
             // Initial highlight from default index
@@ -525,11 +527,11 @@ namespace OpenRCT2::Ui::Windows
             if (left < 0 || left >= ItemWidth * NumColumns)
                 return -1;
 
-            int32_t columnNum = left / ItemWidth;
+            int32_t columnNum = left / std::max(1, ItemWidth);
             if (columnNum >= NumColumns)
                 return -1;
 
-            int32_t rowNum = top / ItemHeight;
+            int32_t rowNum = top / std::max(1, ItemHeight);
             if (rowNum >= NumRows)
                 return -1;
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -67,6 +67,55 @@ namespace OpenRCT2::Ui::Windows
         int32_t ItemHeight;
         int32_t ItemPadding;
         bool ListVertically;
+        bool IsSearchable;
+
+        void FilterItems()
+        {
+            gDropdown.numFilteredItems = 0;
+            if (gDropdown.searchText[0] == '\0')
+            {
+                for (int32_t i = 0; i < gDropdown.numItems; i++)
+                {
+                    gDropdown.filteredItems[gDropdown.numFilteredItems++] = i;
+                }
+            }
+            else
+            {
+                for (int32_t i = 0; i < gDropdown.numItems; i++)
+                {
+                    if (gDropdown.items[i].isSeparator())
+                        continue;
+
+                    if (String::fuzzyContains(gDropdown.items[i].text, gDropdown.searchText))
+                    {
+                        gDropdown.filteredItems[gDropdown.numFilteredItems++] = i;
+                    }
+                }
+            }
+
+            if (gDropdown.numFilteredItems > 0)
+            {
+                if (!ListVertically)
+                {
+                    NumRows = (gDropdown.numFilteredItems + NumColumns - 1) / NumColumns;
+                }
+                else
+                {
+                    NumColumns = 1;
+                    NumRows = gDropdown.numFilteredItems;
+                }
+            }
+            else
+            {
+                NumRows = 1;
+                NumColumns = 1;
+            }
+
+            if (gDropdown.highlightedIndex >= gDropdown.numFilteredItems)
+            {
+                gDropdown.highlightedIndex = gDropdown.numFilteredItems - 1;
+            }
+        }
 
     public:
         void onOpen() override
@@ -77,7 +126,71 @@ namespace OpenRCT2::Ui::Windows
             gDropdown.highlightedIndex = -1;
             gDropdown.hasTooltips = false;
             gDropdown.defaultIndex = -1;
+            gDropdown.searchText[0] = '\0';
+            gDropdown.numFilteredItems = 0;
+            IsSearchable = false;
+
             InputSetState(InputState::DropdownActive);
+        }
+
+        void onTextInput(WidgetIndex widgetIndex, std::string_view text) override
+        {
+            if (!IsSearchable)
+                return;
+
+            String::safeConcat(gDropdown.searchText, text.data(), sizeof(gDropdown.searchText));
+            FilterItems();
+            invalidate();
+        }
+
+        void onKeyDown(uint32_t key)
+        {
+            if (!IsSearchable)
+                return;
+
+            switch (key)
+            {
+                case SDLK_BACKSPACE:
+                {
+                    size_t len = strlen(gDropdown.searchText);
+                    if (len > 0)
+                    {
+                        gDropdown.searchText[len - 1] = '\0';
+                        FilterItems();
+                        invalidate();
+                    }
+                    break;
+                }
+                case SDLK_ESCAPE:
+                    WindowDropdownClose();
+                    break;
+                case SDLK_RETURN:
+                case SDLK_KP_ENTER:
+                    if (gDropdown.numFilteredItems > 0)
+                    {
+                        int32_t index = gDropdown.highlightedIndex;
+                        if (index < 0)
+                            index = 0;
+                        if (index < gDropdown.numFilteredItems)
+                        {
+                            auto actualIndex = gDropdown.filteredItems[index];
+                            WindowDropdownSelectItem(actualIndex);
+                        }
+                    }
+                    break;
+                case SDLK_UP:
+                    gDropdown.highlightedIndex--;
+                    if (gDropdown.highlightedIndex < 0)
+                        gDropdown.highlightedIndex = gDropdown.numFilteredItems - 1;
+                    invalidate();
+                    break;
+                case SDLK_DOWN:
+                    gDropdown.highlightedIndex++;
+                    if (gDropdown.highlightedIndex >= gDropdown.numFilteredItems)
+                        gDropdown.highlightedIndex = 0;
+                    invalidate();
+                    break;
+            }
         }
 
         static int32_t GetDefaultRowHeight()
@@ -181,9 +294,39 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
 
             int32_t highlightedIndex = gDropdown.highlightedIndex;
-
-            for (int32_t i = 0; i < gDropdown.numItems; i++)
+            int32_t yOffset = 2;
+            if (IsSearchable)
             {
+                // Draw search bar
+                const ScreenCoordsXY searchBoxTopLeft = windowPos + ScreenCoordsXY{ 2, 2 };
+                const ScreenCoordsXY searchBoxBottomRight = searchBoxTopLeft + ScreenCoordsXY{ width - 5, ItemHeight - 1 };
+                Rectangle::fillInset(rt, { searchBoxTopLeft, searchBoxBottomRight }, colours[0], Rectangle::BorderStyle::inset);
+
+                // Draw search indicator triangle (mimic dropdown arrow)
+                const ScreenCoordsXY trianglePos = { windowPos.x + width - 11, windowPos.y + 3 };
+                drawText(rt, trianglePos, STR_DROPDOWN_GLYPH);
+
+                Formatter ft;
+                ft.Add<const utf8*>(gDropdown.searchText);
+                ft.Add<const utf8*>(TextBoxCaretIsFlashed() ? u8"_" : u8"");
+                drawTextEllipsised(
+                    rt, searchBoxTopLeft + ScreenCoordsXY{ 1, 1 }, width - 15, STR_STRING_STRINGID, ft, { { colours[0].colour } });
+
+                yOffset += ItemHeight + 2;
+            }
+
+            if (gDropdown.numFilteredItems == 0 && IsSearchable && gDropdown.searchText[0] != '\0')
+            {
+                ScreenCoordsXY screenCoords = windowPos + ScreenCoordsXY{ 2, yOffset };
+                drawText(
+                    rt, screenCoords + ScreenCoordsXY{ 2, 1 }, STR_NO_MATCHES_FOUND, {},
+                    { { colours[0].colour, { ColourFlag::inset } } });
+                return;
+            }
+
+            for (int32_t i = 0; i < gDropdown.numFilteredItems; i++)
+            {
+                int32_t actualIndex = gDropdown.filteredItems[i];
                 ScreenCoordsXY cellCoords;
                 if (ListVertically)
                     cellCoords = { i / NumRows, i % NumRows };
@@ -191,7 +334,7 @@ namespace OpenRCT2::Ui::Windows
                     cellCoords = { i % NumColumns, i / NumColumns };
 
                 ScreenCoordsXY screenCoords = windowPos
-                    + ScreenCoordsXY{ 2 + (cellCoords.x * ItemWidth), 2 + (cellCoords.y * ItemHeight) };
+                    + ScreenCoordsXY{ 2 + (cellCoords.x * ItemWidth), yOffset + (cellCoords.y * ItemHeight) };
 
                 bool highlighted = (i == highlightedIndex);
                 if (highlighted)
@@ -201,7 +344,7 @@ namespace OpenRCT2::Ui::Windows
                     Rectangle::filter(rt, { screenCoords, rightBottom }, FilterPaletteID::paletteDarken3);
                 }
 
-                if (gDropdown.items[i].isSeparator())
+                if (gDropdown.items[actualIndex].isSeparator())
                 {
                     drawSeparator(rt, screenCoords);
                 }
@@ -210,12 +353,12 @@ namespace OpenRCT2::Ui::Windows
                     RenderTarget clippedRT;
                     if (ClipRenderTarget(clippedRT, rt, screenCoords, ItemWidth, ItemHeight))
                     {
-                        gDropdown.cellDrawFunction.value()(clippedRT, gDropdown.items[i], highlighted);
+                        gDropdown.cellDrawFunction.value()(clippedRT, gDropdown.items[actualIndex], highlighted);
                     }
                 }
                 else
                 {
-                    drawItem(rt, screenCoords, i);
+                    drawItem(rt, screenCoords, actualIndex);
                 }
             }
         }
@@ -238,11 +381,18 @@ namespace OpenRCT2::Ui::Windows
             ItemPadding = (txtFlags & Dropdown::Flag::CustomHeight) ? 0 : GetAdditionalRowPadding();
 
             gDropdown.numItems = static_cast<int32_t>(numItems);
-            if (gDropdown.numItems > 1)
+            IsSearchable = (gDropdown.numItems > 10);
+            FilterItems();
+
+            if (gDropdown.numFilteredItems > 0)
             {
-                int32_t numAvailableRows = std::max(1, getSpaceUntilBottom(screenPos, extraY) / ItemHeight);
-                NumRows = std::min({ gDropdown.numItems, numAvailableRows, numRowsPerColumn });
-                NumColumns = (gDropdown.numItems + NumRows - 1) / NumRows;
+                int32_t availableHeight = getSpaceUntilBottom(screenPos, extraY);
+                if (IsSearchable)
+                    availableHeight -= (ItemHeight + 2);
+
+                int32_t numAvailableRows = std::max(1, availableHeight / ItemHeight);
+                NumRows = std::min({ gDropdown.numFilteredItems, numAvailableRows, numRowsPerColumn });
+                NumColumns = (gDropdown.numFilteredItems + NumRows - 1) / NumRows;
             }
             else
             {
@@ -298,7 +448,13 @@ namespace OpenRCT2::Ui::Windows
 
         int32_t GetIndexFromPoint(const ScreenCoordsXY& loc)
         {
-            int32_t top = loc.y - windowPos.y - 2;
+            int32_t yOffset = 2;
+            if (IsSearchable)
+            {
+                yOffset += ItemHeight + 2;
+            }
+
+            int32_t top = loc.y - windowPos.y - yOffset;
             if (top < 0)
                 return -1;
 
@@ -323,10 +479,10 @@ namespace OpenRCT2::Ui::Windows
             else
                 dropdownIndex = rowNum * NumColumns + columnNum;
 
-            if (dropdownIndex >= gDropdown.numItems)
+            if (dropdownIndex >= gDropdown.numFilteredItems)
                 return -1;
 
-            return dropdownIndex;
+            return gDropdown.filteredItems[dropdownIndex];
         }
 
     private:
@@ -334,7 +490,11 @@ namespace OpenRCT2::Ui::Windows
         {
             // Calculate position and size
             const auto ddWidth = ItemWidth * NumColumns + 3;
-            const auto ddHeight = ItemHeight * NumRows + 3;
+            auto ddHeight = ItemHeight * NumRows + 3;
+            if (IsSearchable)
+            {
+                ddHeight += ItemHeight + 2;
+            }
 
             int32_t screenWidth = ContextGetWidth();
             int32_t screenHeight = ContextGetHeight();
@@ -495,6 +655,50 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::dropdown);
+    }
+
+    void WindowDropdownSelectItem(int32_t index)
+    {
+        auto* windowMgr = GetWindowManager();
+        for (auto& w : gWindowList)
+        {
+            if (w->classification != WindowClass::dropdown && !w->flags.has(WindowFlag::dead))
+            {
+                if (gPressedWidget.windowClassification == w->classification
+                    && gPressedWidget.windowNumber == w->number)
+                {
+                    windowMgr->CloseByClass(WindowClass::dropdown);
+                    _inputState = InputState::Normal;
+                    gInputFlags.unset(InputFlag::widgetPressed);
+                    windowMgr->InvalidateWidgetByNumber(w->classification, w->number, gPressedWidget.widgetIndex);
+                    w->onDropdown(gPressedWidget.widgetIndex, index);
+                    return;
+                }
+            }
+        }
+        windowMgr->CloseByClass(WindowClass::dropdown);
+    }
+
+    void WindowDropdownHandleKeyDown(uint32_t key)
+    {
+        auto* windowMgr = GetWindowManager();
+        auto* w = windowMgr->FindByClass(WindowClass::dropdown);
+        if (w != nullptr)
+        {
+            auto* ddWnd = static_cast<DropdownWindow*>(w);
+            ddWnd->onKeyDown(key);
+        }
+    }
+
+    void WindowDropdownHandleTextInput(std::string_view text)
+    {
+        auto* windowMgr = GetWindowManager();
+        auto* w = windowMgr->FindByClass(WindowClass::dropdown);
+        if (w != nullptr)
+        {
+            auto* ddWnd = static_cast<DropdownWindow*>(w);
+            ddWnd->onTextInput(WIDX_BACKGROUND, text);
+        }
     }
 
     /**

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <SDL.h>
 #include <algorithm>
 #include <bitset>
 #include <iterator>
@@ -310,7 +311,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<const utf8*>(gDropdown.searchText);
                 ft.Add<const utf8*>(TextBoxCaretIsFlashed() ? u8"_" : u8"");
                 drawTextEllipsised(
-                    rt, searchBoxTopLeft + ScreenCoordsXY{ 1, 1 }, width - 15, STR_STRING_STRINGID, ft, { { colours[0].colour } });
+                    rt, searchBoxTopLeft + ScreenCoordsXY{ 1, 1 }, width - 15, STR_STRING_STRINGID, ft, colours[0].colour);
 
                 yOffset += ItemHeight + 2;
             }
@@ -664,8 +665,7 @@ namespace OpenRCT2::Ui::Windows
         {
             if (w->classification != WindowClass::dropdown && !w->flags.has(WindowFlag::dead))
             {
-                if (gPressedWidget.windowClassification == w->classification
-                    && gPressedWidget.windowNumber == w->number)
+                if (gPressedWidget.windowClassification == w->classification && gPressedWidget.windowNumber == w->number)
                 {
                     windowMgr->CloseByClass(WindowClass::dropdown);
                     _inputState = InputState::Normal;

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -62,13 +62,13 @@ namespace OpenRCT2::Ui::Windows
 
     class DropdownWindow final : public Window
     {
-        int32_t NumColumns;
-        int32_t NumRows;
-        int32_t ItemWidth;
-        int32_t ItemHeight;
-        int32_t ItemPadding;
-        bool ListVertically;
-        bool IsSearchable;
+        int32_t NumColumns = 1;
+        int32_t NumRows = 1;
+        int32_t ItemWidth = 1;
+        int32_t ItemHeight = 1;
+        int32_t ItemPadding = 0;
+        bool ListVertically = true;
+        bool IsSearchable = false;
 
         void FilterItems()
         {
@@ -124,12 +124,16 @@ namespace OpenRCT2::Ui::Windows
             setWidgets(kWindowDropdownWidgets);
 
             // Input state
+            NumColumns = 1;
+            NumRows = 1;
+            ListVertically = true;
+            IsSearchable = false;
+
             gDropdown.highlightedIndex = -1;
             gDropdown.hasTooltips = false;
             gDropdown.defaultIndex = -1;
             gDropdown.searchText[0] = '\0';
             gDropdown.numFilteredItems = 0;
-            IsSearchable = false;
 
             InputSetState(InputState::DropdownActive);
         }
@@ -383,6 +387,7 @@ namespace OpenRCT2::Ui::Windows
 
             gDropdown.numItems = static_cast<int32_t>(numItems);
             IsSearchable = (gDropdown.numItems > 10);
+            ListVertically = true;
             FilterItems();
 
             if (gDropdown.numFilteredItems > 0)
@@ -403,9 +408,6 @@ namespace OpenRCT2::Ui::Windows
             }
 
             ItemWidth = itemWidth;
-
-            // Text dropdowns are listed horizontally
-            ListVertically = true;
 
             UpdateSizeAndPosition(screenPos, extraY);
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -194,13 +194,13 @@ namespace OpenRCT2::Ui::Windows
                 case SDLK_KP_ENTER:
                 {
                     int32_t index = gDropdown.highlightedIndex;
-                    if (index == -1 && gDropdown.numFilteredItems > 0)
-                    {
-                        index = gDropdown.filteredItems[0];
-                    }
                     if (index != -1)
                     {
                         WindowDropdownSelectItem(index);
+                    }
+                    else
+                    {
+                        WindowDropdownClose();
                     }
                     break;
                 }
@@ -492,6 +492,8 @@ namespace OpenRCT2::Ui::Windows
             // image dropdowns are listed horizontally
             ListVertically = false;
             IsSearchable = false;
+
+            gDropdown.highlightedIndex = gDropdown.defaultIndex;
             FilterItems();
             UpdateSizeAndPosition(screenPos, extraY);
 
@@ -508,6 +510,10 @@ namespace OpenRCT2::Ui::Windows
                 yOffset += ItemHeight + 2;
             }
 
+            // If the mouse is in the padding/search box area, no item is selected
+            if (loc.y < windowPos.y + yOffset)
+                return -1;
+
             int32_t top = loc.y - windowPos.y - yOffset;
             if (top < 0)
                 return -1;
@@ -516,7 +522,7 @@ namespace OpenRCT2::Ui::Windows
             if (left >= width)
                 return -1;
             left -= 2;
-            if (left < 0)
+            if (left < 0 || left >= ItemWidth * NumColumns)
                 return -1;
 
             int32_t columnNum = left / ItemWidth;
@@ -639,6 +645,7 @@ namespace OpenRCT2::Ui::Windows
 
         gDropdown.searchText[0] = '\0';
         gDropdown.numFilteredItems = 0;
+        gDropdown.highlightedIndex = -1;
 
         // Create the window (width/height position are set later)
         auto* windowMgr = GetWindowManager();
@@ -689,6 +696,7 @@ namespace OpenRCT2::Ui::Windows
 
         gDropdown.searchText[0] = '\0';
         gDropdown.numFilteredItems = 0;
+        gDropdown.highlightedIndex = -1;
 
         // Create the window (width/height position are set later)
         auto* windowMgr = GetWindowManager();

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -30,6 +30,7 @@
 #include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Language.h>
 #include <openrct2/ui/WindowManager.h>
+#include <string>
 
 using namespace OpenRCT2::Drawing;
 
@@ -69,6 +70,9 @@ namespace OpenRCT2::Ui::Windows
         int32_t ItemPadding = 0;
         bool ListVertically = true;
         bool IsSearchable = false;
+        int32_t MaxRowsPerColumn = Dropdown::kItemsMaxSize;
+        ScreenCoordsXY BaseScreenPos;
+        int32_t BaseExtraY;
 
         void FilterItems()
         {
@@ -98,12 +102,18 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (!ListVertically)
                 {
+                    NumColumns = std::max(1, NumColumns);
                     NumRows = (gDropdown.numFilteredItems + NumColumns - 1) / NumColumns;
                 }
                 else
                 {
-                    NumColumns = 1;
-                    NumRows = gDropdown.numFilteredItems;
+                    int32_t availableHeight = getSpaceUntilBottom(BaseScreenPos, BaseExtraY);
+                    if (IsSearchable)
+                        availableHeight -= (ItemHeight + 2);
+
+                    int32_t numAvailableRows = std::max(1, availableHeight / ItemHeight);
+                    NumRows = std::min({ gDropdown.numFilteredItems, numAvailableRows, MaxRowsPerColumn });
+                    NumColumns = (gDropdown.numFilteredItems + NumRows - 1) / NumRows;
                 }
             }
             else
@@ -116,6 +126,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 gDropdown.highlightedIndex = gDropdown.numFilteredItems - 1;
             }
+        }
+
+        void onResize() override
+        {
+            UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
         }
 
     public:
@@ -145,6 +160,7 @@ namespace OpenRCT2::Ui::Windows
 
             String::safeConcat(gDropdown.searchText, text.data(), sizeof(gDropdown.searchText));
             FilterItems();
+            UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
             invalidate();
         }
 
@@ -162,6 +178,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         gDropdown.searchText[len - 1] = '\0';
                         FilterItems();
+                        UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
                         invalidate();
                     }
                     break;
@@ -307,15 +324,15 @@ namespace OpenRCT2::Ui::Windows
                 const ScreenCoordsXY searchBoxBottomRight = searchBoxTopLeft + ScreenCoordsXY{ width - 5, ItemHeight - 1 };
                 Rectangle::fillInset(rt, { searchBoxTopLeft, searchBoxBottomRight }, colours[0], Rectangle::BorderStyle::inset);
 
-                // Draw search indicator triangle (mimic dropdown arrow)
-                const ScreenCoordsXY trianglePos = { windowPos.x + width - 11, windowPos.y + 3 };
-                drawText(rt, trianglePos, STR_DROPDOWN_GLYPH);
+                std::string searchDisplay = std::string(reinterpret_cast<const char*>(gDropdown.searchText));
+                if (TextBoxCaretIsFlashed())
+                {
+                    searchDisplay += "_";
+                }
 
                 Formatter ft;
-                ft.Add<const utf8*>(gDropdown.searchText);
-                ft.Add<const utf8*>(TextBoxCaretIsFlashed() ? u8"_" : u8"");
-                drawTextEllipsised(
-                    rt, searchBoxTopLeft + ScreenCoordsXY{ 1, 1 }, width - 15, STR_STRING_STRINGID, ft, colours[0].colour);
+                ft.Add<const char*>(searchDisplay.c_str());
+                drawTextEllipsised(rt, searchBoxTopLeft + ScreenCoordsXY{ 1, 1 }, width - 7, STR_STRING, ft, colours[0].colour);
 
                 yOffset += ItemHeight + 2;
             }
@@ -384,32 +401,16 @@ namespace OpenRCT2::Ui::Windows
             // Set and calculate num items, rows and columns
             ItemHeight = (txtFlags & Dropdown::Flag::CustomHeight) ? customItemHeight : GetDefaultRowHeight();
             ItemPadding = (txtFlags & Dropdown::Flag::CustomHeight) ? 0 : GetAdditionalRowPadding();
+            ItemWidth = itemWidth;
+            BaseScreenPos = screenPos;
+            BaseExtraY = extraY;
+            MaxRowsPerColumn = numRowsPerColumn > 0 ? numRowsPerColumn : Dropdown::kItemsMaxSize;
 
             gDropdown.numItems = static_cast<int32_t>(numItems);
             IsSearchable = (gDropdown.numItems > 10);
             ListVertically = true;
             FilterItems();
-
-            if (gDropdown.numFilteredItems > 0)
-            {
-                int32_t availableHeight = getSpaceUntilBottom(screenPos, extraY);
-                if (IsSearchable)
-                    availableHeight -= (ItemHeight + 2);
-
-                int32_t numAvailableRows = std::max(1, availableHeight / ItemHeight);
-                NumRows = std::min({ gDropdown.numFilteredItems, numAvailableRows, numRowsPerColumn });
-                NumColumns = (gDropdown.numFilteredItems + NumRows - 1) / NumRows;
-            }
-            else
-            {
-                // There must always be at least one column to prevent dividing by zero
-                NumRows = 1;
-                NumColumns = 1;
-            }
-
-            ItemWidth = itemWidth;
-
-            UpdateSizeAndPosition(screenPos, extraY);
+            UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
 
             if (colour.flags.has(ColourFlag::translucent))
                 flags |= WindowFlag::transparent;
@@ -424,24 +425,24 @@ namespace OpenRCT2::Ui::Windows
             ItemWidth = itemWidth;
             ItemHeight = itemHeight;
             gDropdown.numItems = numItems;
+            BaseScreenPos = screenPos;
+            BaseExtraY = extraY;
+            NumColumns = std::max(1, numColumns);
 
             // There must always be at least one column and row to prevent dividing by zero
             if (gDropdown.numItems == 0)
             {
-                NumColumns = 1;
                 NumRows = 1;
             }
             else
             {
-                NumColumns = std::max(1, numColumns);
-                NumRows = gDropdown.numItems / NumColumns;
-                if (gDropdown.numItems % NumColumns != 0)
-                    NumRows++;
+                NumRows = (gDropdown.numItems + NumColumns - 1) / NumColumns;
             }
 
             // image dropdowns are listed horizontally
             ListVertically = false;
-
+            IsSearchable = false;
+            FilterItems();
             UpdateSizeAndPosition(screenPos, extraY);
 
             if (colour.flags.has(ColourFlag::translucent))

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
+#include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/Input.h>
@@ -122,9 +123,22 @@ namespace OpenRCT2::Ui::Windows
                 NumColumns = 1;
             }
 
-            if (gDropdown.highlightedIndex >= gDropdown.numFilteredItems)
+            // Ensure highlighted index is still valid within the filtered items
+            if (gDropdown.highlightedIndex != -1)
             {
-                gDropdown.highlightedIndex = gDropdown.numFilteredItems - 1;
+                bool stillVisible = false;
+                for (int32_t i = 0; i < gDropdown.numFilteredItems; i++)
+                {
+                    if (gDropdown.filteredItems[i] == gDropdown.highlightedIndex)
+                    {
+                        stillVisible = true;
+                        break;
+                    }
+                }
+                if (!stillVisible)
+                {
+                    gDropdown.highlightedIndex = -1;
+                }
             }
         }
 
@@ -143,12 +157,6 @@ namespace OpenRCT2::Ui::Windows
             NumRows = 1;
             ListVertically = true;
             IsSearchable = false;
-
-            gDropdown.highlightedIndex = -1;
-            gDropdown.hasTooltips = false;
-            gDropdown.defaultIndex = -1;
-            gDropdown.searchText[0] = '\0';
-            gDropdown.numFilteredItems = 0;
 
             InputSetState(InputState::DropdownActive);
         }
@@ -173,14 +181,10 @@ namespace OpenRCT2::Ui::Windows
             {
                 case SDLK_BACKSPACE:
                 {
-                    size_t len = strlen(gDropdown.searchText);
-                    if (len > 0)
-                    {
-                        gDropdown.searchText[len - 1] = '\0';
-                        FilterItems();
-                        UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
-                        invalidate();
-                    }
+                    String::backspace(gDropdown.searchText);
+                    FilterItems();
+                    UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
+                    invalidate();
                     break;
                 }
                 case SDLK_ESCAPE:
@@ -188,30 +192,66 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case SDLK_RETURN:
                 case SDLK_KP_ENTER:
-                    if (gDropdown.numFilteredItems > 0)
+                {
+                    int32_t index = gDropdown.highlightedIndex;
+                    if (index == -1 && gDropdown.numFilteredItems > 0)
                     {
-                        int32_t index = gDropdown.highlightedIndex;
-                        if (index < 0)
-                            index = 0;
-                        if (index < gDropdown.numFilteredItems)
-                        {
-                            auto actualIndex = gDropdown.filteredItems[index];
-                            WindowDropdownSelectItem(actualIndex);
-                        }
+                        index = gDropdown.filteredItems[0];
+                    }
+                    if (index != -1)
+                    {
+                        WindowDropdownSelectItem(index);
                     }
                     break;
+                }
                 case SDLK_UP:
-                    gDropdown.highlightedIndex--;
-                    if (gDropdown.highlightedIndex < 0)
-                        gDropdown.highlightedIndex = gDropdown.numFilteredItems - 1;
+                {
+                    if (gDropdown.numFilteredItems == 0)
+                        break;
+
+                    int32_t currentFilteredIdx = -1;
+                    for (int32_t i = 0; i < gDropdown.numFilteredItems; i++)
+                    {
+                        if (gDropdown.filteredItems[i] == gDropdown.highlightedIndex)
+                        {
+                            currentFilteredIdx = i;
+                            break;
+                        }
+                    }
+
+                    if (currentFilteredIdx == -1)
+                        currentFilteredIdx = gDropdown.numFilteredItems - 1;
+                    else
+                        currentFilteredIdx = (currentFilteredIdx + gDropdown.numFilteredItems - 1) % gDropdown.numFilteredItems;
+
+                    gDropdown.highlightedIndex = gDropdown.filteredItems[currentFilteredIdx];
                     invalidate();
                     break;
+                }
                 case SDLK_DOWN:
-                    gDropdown.highlightedIndex++;
-                    if (gDropdown.highlightedIndex >= gDropdown.numFilteredItems)
-                        gDropdown.highlightedIndex = 0;
+                {
+                    if (gDropdown.numFilteredItems == 0)
+                        break;
+
+                    int32_t currentFilteredIdx = -1;
+                    for (int32_t i = 0; i < gDropdown.numFilteredItems; i++)
+                    {
+                        if (gDropdown.filteredItems[i] == gDropdown.highlightedIndex)
+                        {
+                            currentFilteredIdx = i;
+                            break;
+                        }
+                    }
+
+                    if (currentFilteredIdx == -1)
+                        currentFilteredIdx = 0;
+                    else
+                        currentFilteredIdx = (currentFilteredIdx + 1) % gDropdown.numFilteredItems;
+
+                    gDropdown.highlightedIndex = gDropdown.filteredItems[currentFilteredIdx];
                     invalidate();
                     break;
+                }
             }
         }
 
@@ -225,11 +265,8 @@ namespace OpenRCT2::Ui::Windows
             return Config::Get().interface.enlargedUi ? 6 : 0;
         }
 
-        void drawItem(RenderTarget& rt, ScreenCoordsXY screenCoords, int32_t i)
+        void drawItem(RenderTarget& rt, ScreenCoordsXY screenCoords, int32_t i, bool highlighted)
         {
-            const int32_t highlightedIndex = gDropdown.highlightedIndex;
-            const bool highlighted = (i == highlightedIndex);
-
             const auto& item = gDropdown.items[i];
             switch (item.type)
             {
@@ -264,7 +301,7 @@ namespace OpenRCT2::Ui::Windows
                 case Dropdown::ItemType::colour:
                 {
                     auto image = item.image;
-                    if (highlightedIndex == i)
+                    if (highlighted)
                         image = image.WithIndexOffset(1);
                     GfxDrawSprite(rt, image, screenCoords);
                     break;
@@ -315,7 +352,6 @@ namespace OpenRCT2::Ui::Windows
         {
             drawWidgets(rt);
 
-            int32_t highlightedIndex = gDropdown.highlightedIndex;
             int32_t yOffset = 2;
             if (IsSearchable)
             {
@@ -358,12 +394,22 @@ namespace OpenRCT2::Ui::Windows
                 ScreenCoordsXY screenCoords = windowPos
                     + ScreenCoordsXY{ 2 + (cellCoords.x * ItemWidth), yOffset + (cellCoords.y * ItemHeight) };
 
-                bool highlighted = (i == highlightedIndex);
+                bool highlighted = (actualIndex == gDropdown.highlightedIndex);
                 if (highlighted)
                 {
                     // Darken the cell's background slightly when highlighted
                     const ScreenCoordsXY rightBottom = screenCoords + ScreenCoordsXY{ ItemWidth - 1, ItemHeight - 1 };
                     Rectangle::filter(rt, { screenCoords, rightBottom }, FilterPaletteID::paletteDarken3);
+
+                    if (gDropdown.hasTooltips && gDropdown.lastTooltipHover != actualIndex)
+                    {
+                        gDropdown.lastTooltipHover = actualIndex;
+                        const auto& item = gDropdown.items[actualIndex];
+                        if (item.tooltip != kStringIdEmpty)
+                        {
+                            WindowTooltipShow({ item.tooltip, {} }, screenCoords);
+                        }
+                    }
                 }
 
                 if (gDropdown.items[actualIndex].isSeparator())
@@ -380,7 +426,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    drawItem(rt, screenCoords, actualIndex);
+                    drawItem(rt, screenCoords, actualIndex, highlighted);
                 }
             }
         }
@@ -409,7 +455,11 @@ namespace OpenRCT2::Ui::Windows
             gDropdown.numItems = static_cast<int32_t>(numItems);
             IsSearchable = (gDropdown.numItems > 10);
             ListVertically = true;
+
+            // Initial highlight from default index
+            gDropdown.highlightedIndex = gDropdown.defaultIndex;
             FilterItems();
+
             UpdateSizeAndPosition(BaseScreenPos, BaseExtraY);
 
             if (colour.flags.has(ColourFlag::translucent))
@@ -587,6 +637,9 @@ namespace OpenRCT2::Ui::Windows
 
         WindowDropdownClose();
 
+        gDropdown.searchText[0] = '\0';
+        gDropdown.numFilteredItems = 0;
+
         // Create the window (width/height position are set later)
         auto* windowMgr = GetWindowManager();
         auto* w = windowMgr->Create<DropdownWindow>(
@@ -633,6 +686,9 @@ namespace OpenRCT2::Ui::Windows
 
         // Close existing dropdown
         WindowDropdownClose();
+
+        gDropdown.searchText[0] = '\0';
+        gDropdown.numFilteredItems = 0;
 
         // Create the window (width/height position are set later)
         auto* windowMgr = GetWindowManager();

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -317,7 +317,8 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[1].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen, TOP_TOOLBAR_VIEW_MENU_COUNT);
+                colours[1].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen | Dropdown::Flag::NoSearch,
+                TOP_TOOLBAR_VIEW_MENU_COUNT);
 
             auto mvpFlags = WindowGetMain()->viewport->flags;
             gDropdown.items[DDIDX_UNDERGROUND_INSIDE].setChecked(mvpFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
@@ -449,7 +450,7 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[1].withFlag(ColourFlag::translucent, true), 0, i);
+                colours[1].withFlag(ColourFlag::translucent, true), Dropdown::Flag::NoSearch, i);
             gDropdown.defaultIndex = DDIDX_SHOW_MAP;
         }
 
@@ -516,7 +517,7 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[0].withFlag(ColourFlag::translucent, true), 0, num_items);
+                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::NoSearch, num_items);
 
             // Set checkmarks
             if (gGameSpeed <= 4)
@@ -628,7 +629,8 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen, numItems);
+                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen | Dropdown::Flag::NoSearch,
+                numItems);
         }
 
         void initCheatsMenu(Widget& widget)
@@ -652,7 +654,8 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen, TOP_TOOLBAR_CHEATS_COUNT);
+                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen | Dropdown::Flag::NoSearch,
+                TOP_TOOLBAR_CHEATS_COUNT);
 
             // Disable items that are not yet available in multiplayer
             if (Network::GetMode() != Network::Mode::none)
@@ -728,7 +731,8 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen, TOP_TOOLBAR_DEBUG_COUNT);
+                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen | Dropdown::Flag::NoSearch,
+                TOP_TOOLBAR_DEBUG_COUNT);
 
             auto* windowMgr = GetWindowManager();
             gDropdown.items[DDIDX_CONSOLE].setChecked(windowMgr->FindByClass(WindowClass::console) != nullptr);
@@ -772,7 +776,7 @@ namespace OpenRCT2::Ui::Windows
 
             WindowDropdownShowText(
                 { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(),
-                colours[0].withFlag(ColourFlag::translucent, true), 0, TOP_TOOLBAR_NETWORK_COUNT);
+                colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::NoSearch, TOP_TOOLBAR_NETWORK_COUNT);
 
             gDropdown.items[DDIDX_MULTIPLAYER_RECONNECT].setDisabled(!Network::IsDesynchronised());
 

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -880,19 +880,27 @@ namespace OpenRCT2::String
         auto h = toUpper(haystack);
         auto n = toUpper(needle);
 
-        size_t hIdx = 0;
-        size_t nIdx = 0;
+        const utf8* hPtr = h.c_str();
+        const utf8* nPtr = n.c_str();
 
-        while (hIdx < h.size() && nIdx < n.size())
+        uint32_t nCodepoint = UTF8GetNext(nPtr, &nPtr);
+        while (nCodepoint != 0)
         {
-            if (h[hIdx] == n[nIdx])
+            uint32_t hCodepoint = UTF8GetNext(hPtr, &hPtr);
+            while (hCodepoint != 0 && hCodepoint != nCodepoint)
             {
-                nIdx++;
+                hCodepoint = UTF8GetNext(hPtr, &hPtr);
             }
-            hIdx++;
+
+            if (hCodepoint == 0)
+            {
+                return false;
+            }
+
+            nCodepoint = UTF8GetNext(nPtr, &nPtr);
         }
 
-        return nIdx == n.size();
+        return true;
     }
 
     void backspace(char* str)

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -40,7 +40,10 @@
 
 #if defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))
     #include <strings.h>
-    #define _stricmp(x, y) strcasecmp((x), (y))
+static int _stricmp(const char* x, const char* y)
+{
+    return strcasecmp(x, y);
+}
 #endif
 
 namespace OpenRCT2::String

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -894,4 +894,19 @@ namespace OpenRCT2::String
 
         return nIdx == n.size();
     }
+
+    void backspace(char* str)
+    {
+        if (str == nullptr || *str == '\0')
+            return;
+
+        char* prev = str;
+        const char* curr = str;
+        while (*curr != '\0')
+        {
+            prev = const_cast<char*>(curr);
+            UTF8GetNext(curr, &curr);
+        }
+        *prev = '\0';
+    }
 } // namespace OpenRCT2::String

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -905,7 +905,10 @@ namespace OpenRCT2::String
         while (*curr != '\0')
         {
             prev = const_cast<char*>(curr);
-            UTF8GetNext(curr, &curr);
+            if (UTF8GetNext(curr, &curr) == 0)
+            {
+                break;
+            }
         }
         *prev = '\0';
     }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -868,4 +868,27 @@ namespace OpenRCT2::String
 
         return result;
     }
+
+    bool fuzzyContains(std::string_view haystack, std::string_view needle)
+    {
+        if (needle.empty())
+            return true;
+
+        auto h = toUpper(haystack);
+        auto n = toUpper(needle);
+
+        size_t hIdx = 0;
+        size_t nIdx = 0;
+
+        while (hIdx < h.size() && nIdx < n.size())
+        {
+            if (h[hIdx] == n[nIdx])
+            {
+                nIdx++;
+            }
+            hIdx++;
+        }
+
+        return nIdx == n.size();
+    }
 } // namespace OpenRCT2::String

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -222,4 +222,5 @@ namespace OpenRCT2::String
     int32_t logicalCmp(char const* a, char const* b);
     char* safeUtf8Copy(char* destination, const char* source, size_t num);
     char* safeConcat(char* destination, const char* source, size_t size);
+    bool fuzzyContains(std::string_view haystack, std::string_view needle);
 } // namespace OpenRCT2::String

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -223,4 +223,5 @@ namespace OpenRCT2::String
     char* safeUtf8Copy(char* destination, const char* source, size_t num);
     char* safeConcat(char* destination, const char* source, size_t size);
     bool fuzzyContains(std::string_view haystack, std::string_view needle);
+    void backspace(char* str);
 } // namespace OpenRCT2::String

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -352,3 +352,42 @@ TEST_F(StringTest, Parse_LargeNumber)
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, 9223372036854775807LL);
 }
+
+TEST_F(StringTest, FuzzyContains)
+{
+    EXPECT_TRUE(String::fuzzyContains("Log Flume", "log"));
+    EXPECT_TRUE(String::fuzzyContains("Log Flume", "LOG"));
+    EXPECT_TRUE(String::fuzzyContains("Log Flume", "lfm"));
+    EXPECT_TRUE(String::fuzzyContains("Log Flume", ""));
+    EXPECT_TRUE(String::fuzzyContains("Junior Roller Coaster", "jrc"));
+    EXPECT_TRUE(String::fuzzyContains("Junior Roller Coaster", "roller"));
+
+    EXPECT_FALSE(String::fuzzyContains("Log Flume", "logs"));
+    EXPECT_FALSE(String::fuzzyContains("Log Flume", "abc"));
+}
+
+TEST_F(StringTest, Backspace)
+{
+    char buf[64];
+
+    strcpy(buf, "test");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, "tes");
+
+    strcpy(buf, "a");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, "");
+
+    strcpy(buf, "");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, "");
+
+    // UTF-8
+    strcpy(buf, u8"ゲスト");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, u8"ゲス");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, u8"ゲ");
+    String::backspace(buf);
+    ASSERT_STREQ(buf, "");
+}

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -364,6 +364,11 @@ TEST_F(StringTest, FuzzyContains)
 
     EXPECT_FALSE(String::fuzzyContains("Log Flume", "logs"));
     EXPECT_FALSE(String::fuzzyContains("Log Flume", "abc"));
+
+    // Unicode / Multi-byte
+    EXPECT_TRUE(String::fuzzyContains(u8"ストリング", u8"トリ"));
+    EXPECT_TRUE(String::fuzzyContains(u8"ストリング", u8"スン"));
+    EXPECT_FALSE(String::fuzzyContains(u8"ストリング", u8"ストス"));
 }
 
 TEST_F(StringTest, Backspace)


### PR DESCRIPTION
Implemented a fuzzy search feature for dropdown menus with more than 10 items.
- Added `OpenRCT2::String::fuzzyContains` for subsequence matching.
- Updated `DropdownState` to track search text and filtered results.
- Enhanced `DropdownWindow` to render a search box and handle filtered rendering.
- Hooked `InputManager` and `UiContext` to route keyboard and text input to active dropdowns.
- Added localized "No matches found" string.

---
*PR created automatically by Jules for task [4314626366268702446](https://jules.google.com/task/4314626366268702446) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable dropdowns with inline search bar, fuzzy filtering, and “No matches found” message for empty results.
  * Type-to-filter, arrow-key navigation, Enter to select, and Escape to close; external selection/input events supported when a dropdown is open.

* **Localization**
  * Added new UI string: “No matches found”.

* **Bug Fixes**
  * Fixed missing end-of-file newline in English locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->