### PR TITLE
Fix crash when multiple subscribers register for the same event

### DIFF
--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -16,25 +16,24 @@
 
 using namespace OpenRCT2::Scripting;
 
-static const EnumMap<HookType> HooksLookupTable(
-    {
-        { "action.query", HookType::actionQuery },
-        { "action.execute", HookType::actionExecute },
-        { "interval.tick", HookType::intervalTick },
-        { "interval.day", HookType::intervalDay },
-        { "network.chat", HookType::networkChat },
-        { "network.authenticate", HookType::networkAuthenticate },
-        { "network.join", HookType::networkJoin },
-        { "network.leave", HookType::networkLeave },
-        { "ride.ratings.calculate", HookType::rideRatingsCalculate },
-        { "action.location", HookType::actionLocation },
-        { "guest.generation", HookType::guestGeneration },
-        { "vehicle.crash", HookType::vehicleCrash },
-        { "map.change", HookType::mapChange },
-        { "map.changed", HookType::mapChanged },
-        { "map.save", HookType::mapSave },
-        { "park.guest.softcap.calculate", HookType::parkCalculateGuestCap },
-    });
+static const EnumMap<HookType> HooksLookupTable({
+    { "action.query", HookType::actionQuery },
+    { "action.execute", HookType::actionExecute },
+    { "interval.tick", HookType::intervalTick },
+    { "interval.day", HookType::intervalDay },
+    { "network.chat", HookType::networkChat },
+    { "network.authenticate", HookType::networkAuthenticate },
+    { "network.join", HookType::networkJoin },
+    { "network.leave", HookType::networkLeave },
+    { "ride.ratings.calculate", HookType::rideRatingsCalculate },
+    { "action.location", HookType::actionLocation },
+    { "guest.generation", HookType::guestGeneration },
+    { "vehicle.crash", HookType::vehicleCrash },
+    { "map.change", HookType::mapChange },
+    { "map.changed", HookType::mapChanged },
+    { "map.save", HookType::mapSave },
+    { "park.guest.softcap.calculate", HookType::parkCalculateGuestCap },
+});
 
 HookType OpenRCT2::Scripting::GetHookType(const std::string& name)
 {
@@ -123,7 +122,8 @@ void HookEngine::Call(HookType type, const JSValue arg, bool isGameStateMutable,
     for (auto& hook : hookList.Hooks)
     {
         JSContext* ctx = hook.Owner ? hook.Owner->GetContext() : _scriptEngine.GetContext();
-        _scriptEngine.ExecutePluginCall(hook.Owner, hook.Function.callback, { JS_DupValue(ctx, arg) }, isGameStateMutable, false);
+        _scriptEngine.ExecutePluginCall(
+            hook.Owner, hook.Function.callback, { JS_DupValue(ctx, arg) }, isGameStateMutable, false);
     }
 
     if (!keepArgsAlive)

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -122,7 +122,15 @@ void HookEngine::Call(HookType type, const JSValue arg, bool isGameStateMutable,
     auto& hookList = GetHookList(type);
     for (auto& hook : hookList.Hooks)
     {
-        _scriptEngine.ExecutePluginCall(hook.Owner, hook.Function.callback, { arg }, isGameStateMutable, keepArgsAlive);
+        JSContext* ctx = hook.Owner ? hook.Owner->GetContext() : _scriptEngine.GetContext();
+        _scriptEngine.ExecutePluginCall(hook.Owner, hook.Function.callback, { JS_DupValue(ctx, arg) }, isGameStateMutable, false);
+    }
+
+    if (!keepArgsAlive)
+    {
+        // One final free as we are the "owner" of the passed arg
+        JSContext* ctx = _scriptEngine.GetContext();
+        JS_FreeValue(ctx, arg);
     }
 }
 

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -16,24 +16,25 @@
 
 using namespace OpenRCT2::Scripting;
 
-static const EnumMap<HookType> HooksLookupTable({
-    { "action.query", HookType::actionQuery },
-    { "action.execute", HookType::actionExecute },
-    { "interval.tick", HookType::intervalTick },
-    { "interval.day", HookType::intervalDay },
-    { "network.chat", HookType::networkChat },
-    { "network.authenticate", HookType::networkAuthenticate },
-    { "network.join", HookType::networkJoin },
-    { "network.leave", HookType::networkLeave },
-    { "ride.ratings.calculate", HookType::rideRatingsCalculate },
-    { "action.location", HookType::actionLocation },
-    { "guest.generation", HookType::guestGeneration },
-    { "vehicle.crash", HookType::vehicleCrash },
-    { "map.change", HookType::mapChange },
-    { "map.changed", HookType::mapChanged },
-    { "map.save", HookType::mapSave },
-    { "park.guest.softcap.calculate", HookType::parkCalculateGuestCap },
-});
+static const EnumMap<HookType> HooksLookupTable(
+    {
+        { "action.query", HookType::actionQuery },
+        { "action.execute", HookType::actionExecute },
+        { "interval.tick", HookType::intervalTick },
+        { "interval.day", HookType::intervalDay },
+        { "network.chat", HookType::networkChat },
+        { "network.authenticate", HookType::networkAuthenticate },
+        { "network.join", HookType::networkJoin },
+        { "network.leave", HookType::networkLeave },
+        { "ride.ratings.calculate", HookType::rideRatingsCalculate },
+        { "action.location", HookType::actionLocation },
+        { "guest.generation", HookType::guestGeneration },
+        { "vehicle.crash", HookType::vehicleCrash },
+        { "map.change", HookType::mapChange },
+        { "map.changed", HookType::mapChanged },
+        { "map.save", HookType::mapSave },
+        { "park.guest.softcap.calculate", HookType::parkCalculateGuestCap },
+    });
 
 HookType OpenRCT2::Scripting::GetHookType(const std::string& name)
 {

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/S6ImportExportTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/SawyerCodingTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/ScenarioPatcherTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ScriptingTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/StringTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/TestData.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/TestData.h"

--- a/test/tests/ScriptingTests.cpp
+++ b/test/tests/ScriptingTests.cpp
@@ -1,0 +1,89 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/GameState.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/scripting/ScriptEngine.h>
+#include <quickjs.h>
+
+using namespace OpenRCT2;
+using namespace OpenRCT2::Scripting;
+
+class ScriptingTests : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        gOpenRCT2Headless = true;
+        gOpenRCT2NoGraphics = true;
+        _context = CreateContext();
+        _context->Initialise();
+    }
+
+    std::unique_ptr<IContext> _context;
+};
+
+#ifdef ENABLE_SCRIPTING
+
+TEST_F(ScriptingTests, MultipleSubscribersToSameEventShouldNotCrash)
+{
+    auto& scriptEngine = static_cast<ScriptEngine&>(_context->GetScriptEngine());
+
+    // Register a plugin that subscribes twice to the same event
+    const char* pluginCode = R"(
+        registerPlugin({
+            name: 'test-plugin',
+            version: '1.0.0',
+            authors: ['test'],
+            type: 'remote',
+            licence: 'MIT',
+            minApiVersion: 0,
+            targetApiVersion: 0,
+            main: function () {
+                context.subscribe('interval.tick', function (e) {
+                    // first subscriber
+                });
+                context.subscribe('interval.tick', function (e) {
+                    // second subscriber
+                });
+            }
+        });
+    )";
+
+    scriptEngine.AddNetworkPlugin(pluginCode);
+    scriptEngine.LoadTransientPlugins();
+    scriptEngine.Tick();
+
+    // Trigger the event. interval.tick passes an object with { tick: number }
+    // We can use HookEngine::Call directly or just call scriptEngine.Tick() if we want it more end-to-end
+    // but interval.tick in HookEngine is called with an object.
+
+    // Actually, HookEngine::Call(HookType::IntervalTick, ...) is what we want.
+    // In ScriptEngine::UpdateIntervals, it doesn't seem to use HookEngine for intervals though.
+    // Wait, HookType::IntervalTick is used in ScriptEngine?
+    // Let's check HookEngine.cpp again for who calls interval.tick.
+
+    // It seems interval.tick is not called by the core, but available.
+    // Let's use an event that is actually called, like 'map.changed' or just manually call HookEngine::Call.
+
+    auto& hookEngine = scriptEngine.GetHookEngine();
+
+    // We need a JSValue to pass to Call.
+    JSContext* ctx = scriptEngine.GetContext();
+    JSValue arg = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, arg, "test", JS_NewInt32(ctx, 1));
+
+    // This should NOT crash.
+    // If it crashes, the test fails by crashing the process.
+    hookEngine.Call(HookType::intervalTick, arg, false);
+}
+
+#endif


### PR DESCRIPTION
Fixed a crash in the QuickJS scripting engine that occurred when multiple subscribers were registered for the same event. Added a C++ headless test to verify the fix.

---
*PR created automatically by Jules for task [6335222043800463464](https://jules.google.com/task/6335222043800463464) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when multiple plugins subscribe to the same game event.
  * Improved memory handling during event dispatch so per-subscriber arguments are managed safely and original arguments are cleaned up reliably.

* **Tests**
  * Added automated test coverage for multi-subscriber event handling to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->