### PR TITLE
Add libuv support for asynchronous asset loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if (MACOS_USE_DEPENDENCIES)
 
     set(MACOS_DYLIBS_VERSION "999-libuv-1")
     set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v${MACOS_DYLIBS_VERSION}-universal-macos-dylibs.zip")
-    set(MACOS_DYLIBS_SHA256 "7a11cf259369d87edc5140a94809f0c937db010eac03f002ad20927f1122db21")
+    set(MACOS_DYLIBS_SHA256 "d96588edccfc294b0d3156169f18cf1368ffb7b145a5605015e5ee0f6bdd63ca")
     set(MACOS_DYLIBS_DIR "${ROOT_DIR}/lib/macos")
     set(MACOS_DYLIBS_URL "https://github.com/janisozaur/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ option(ENABLE_ASAN "Enable the AddressSanitizer.")
 option(ENABLE_UBSAN "Enable the UndefinedBehaviourSanitizer.")
 option(ENABLE_HEADERS_CHECK "Check if include directives in header files are correct. Only works with clang" OFF)
 option(DISABLE_GUI "Don't build GUI. (Headless only.)")
+option(USE_LIBUV "Enable libuv support." ON)
 
 
 if (FORCE32)

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -64,7 +64,7 @@
       -->
       <PreprocessorDefinitions>OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">__AVX2__;__SSE4_1__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>ENABLE_SCRIPTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SCRIPTING;USE_LIBUV;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'!='true'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -74,7 +74,7 @@
     </ClCompile>
     <Link>
       <LargeAddressAware Condition="'$(Platform)'=='Win32'">true</LargeAddressAware>
-      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;Iphlpapi.lib;Userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">fribidi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
@@ -114,7 +114,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>brotlicommon.lib;brotlidec.lib;brotlienc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Breakpad)'=='true' and ('$(Platform)'=='Win32' or '$(Platform)'=='x64')">libbreakpad.lib;libbreakpad_client.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies>bz2.lib;discord-rpc.lib;flac.lib;freetype.lib;libpng16.lib;ogg.lib;SDL2-static.lib;vorbis.lib;vorbisfile.lib;zip.lib;libuv.lib;zlib.lib;zstd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bz2.lib;discord-rpc.lib;flac.lib;freetype.lib;libpng16.lib;ogg.lib;SDL2-static.lib;vorbis.lib;vorbisfile.lib;zip.lib;libuv.lib;Dbghelp.lib;zlib.lib;zstd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/openrct2-cli/openrct2-cli.vcxproj
+++ b/src/openrct2-cli/openrct2-cli.vcxproj
@@ -59,7 +59,7 @@
       <AdditionalOptions>$(OPENRCT2_CL_ADDITIONALOPTIONS) %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libopenrct2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libopenrct2.lib;libuv.lib;dbghelp.lib;Iphlpapi.lib;Userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)openrct2-cli.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -211,6 +211,26 @@ if (NOT MINGW AND NOT MSVC AND NOT EMSCRIPTEN)
     endif ()
 endif ()
 
+if (USE_LIBUV)
+    if (MSVC)
+        find_path(LIBUV_INCLUDE_DIRS uv.h)
+        find_library(LIBUV_LIBRARIES uv)
+    else ()
+        PKG_CHECK_MODULES(LIBUV REQUIRED IMPORTED_TARGET libuv>=1.0)
+    endif ()
+
+    target_include_directories(libopenrct2 SYSTEM PRIVATE ${LIBUV_INCLUDE_DIRS})
+    if (STATIC)
+        target_link_libraries(libopenrct2 ${LIBUV_STATIC_LIBRARIES})
+    else ()
+        if (NOT MSVC)
+            target_link_libraries(libopenrct2 PkgConfig::LIBUV)
+        else ()
+            target_link_libraries(libopenrct2 ${LIBUV_LIBRARIES})
+        endif ()
+    endif ()
+endif ()
+
 if (NOT DISABLE_TTF)
     if (STATIC)
         target_link_libraries(libopenrct2 ${FREETYPE_STATIC_LIBRARIES})
@@ -305,6 +325,7 @@ target_compile_definitions(libopenrct2 PUBLIC
         $<$<BOOL:${DISABLE_TTF}>:DISABLE_TTF>
         $<$<BOOL:${DISABLE_VERSION_CHECKER}>:DISABLE_VERSION_CHECKER>
         $<$<BOOL:${ENABLE_SCRIPTING}>:ENABLE_SCRIPTING>
+        $<$<BOOL:${USE_LIBUV}>:USE_LIBUV>
 )
 
 target_compile_options(libopenrct2 PUBLIC $<$<BOOL:${ENABLE_ASAN}>:-fsanitize=address>)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -92,6 +92,11 @@ using namespace OpenRCT2::Ui;
 
 using OpenRCT2::Audio::IAudioContext;
 
+// Undefine Windows macros that conflict with our functions
+#ifdef CreateDirectory
+    #undef CreateDirectory
+#endif
+
 namespace OpenRCT2
 {
     namespace

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -60,6 +60,7 @@
 #include "paint/Painter.h"
 #include "park/ParkFile.h"
 #include "platform/Crash.h"
+#include "platform/LibuvLoop.h"
 #include "platform/Platform.h"
 #include "profiling/Profiling.h"
 #include "rct2/RCT2.h"
@@ -1461,6 +1462,9 @@ namespace OpenRCT2
             {
                 _scriptEngine.Tick();
             }
+#endif
+#ifdef USE_LIBUV
+            Platform::LibuvLoop::Get().Tick();
 #endif
             _stdInOutConsole.ProcessEvalQueue();
             _uiContext->Tick();

--- a/src/openrct2/TrackImporter.h
+++ b/src/openrct2/TrackImporter.h
@@ -26,6 +26,7 @@ public:
 
     virtual bool Load(const utf8* path) = 0;
     virtual bool LoadFromStream(OpenRCT2::IStream* stream) = 0;
+    virtual bool LoadFromData(std::vector<uint8_t>&& data) = 0;
 
     [[nodiscard]] virtual std::unique_ptr<TrackDesign> Import() = 0;
 };

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -11,6 +11,8 @@
 
 #include "../Context.h"
 #include "../Diagnostic.h"
+#include "../platform/LibuvLoop.h"
+#include "../platform/Platform.h"
 #include "Console.hpp"
 #include "DataSerialiser.h"
 #include "File.h"
@@ -20,8 +22,11 @@
 #include "Numerics.hpp"
 #include "Path.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <list>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -133,6 +138,14 @@ protected:
     virtual std::optional<TItem> Create(int32_t language, const std::string& path) const = 0;
 
     /**
+     * Loads the given file data and creates the item representing the data to store in the index.
+     */
+    virtual std::optional<TItem> Create(int32_t language, const std::string& path, std::vector<uint8_t>&& data) const
+    {
+        return Create(language, path);
+    }
+
+    /**
      * Serialises/DeSerialises an index item to/from the given stream.
      */
     virtual void Serialise(OpenRCT2::DataSerialiser& ds, const TItem& item) const = 0;
@@ -180,6 +193,92 @@ private:
         const size_t totalCount = scanResult.Files.size();
         if (totalCount > 0)
         {
+#ifdef USE_LIBUV
+            struct BuildContext
+            {
+                std::vector<TItem>& AllItems;
+                std::mutex& AllItemsMutex;
+                std::atomic<size_t>& FinishedCount;
+                std::atomic<size_t>& TotalProcessed;
+                const size_t TotalCount;
+                const int32_t Language;
+                const FileIndex<TItem>* Index;
+
+                BuildContext(
+                    std::vector<TItem>& allItems, std::mutex& allItemsMutex, std::atomic<size_t>& finishedCount,
+                    std::atomic<size_t>& totalProcessed, size_t totalCount, int32_t language, const FileIndex<TItem>* index)
+                    : AllItems(allItems)
+                    , AllItemsMutex(allItemsMutex)
+                    , FinishedCount(finishedCount)
+                    , TotalProcessed(totalProcessed)
+                    , TotalCount(totalCount)
+                    , Language(language)
+                    , Index(index)
+                {
+                }
+            };
+
+            struct WorkRequest
+            {
+                uv_work_t req;
+                std::string path;
+                std::vector<uint8_t> data;
+                std::optional<TItem> item;
+                std::shared_ptr<BuildContext> context;
+            };
+
+            std::mutex allItemsMutex;
+            std::atomic<size_t> finishedCount{ 0 };
+            std::atomic<size_t> totalProcessed{ 0 };
+            auto buildContext = std::make_shared<BuildContext>(
+                allItems, allItemsMutex, finishedCount, totalProcessed, totalCount, language, this);
+
+            for (size_t i = 0; i < totalCount; i++)
+            {
+                const auto& filePath = scanResult.Files.at(i);
+                OpenRCT2::Platform::ReadAllBytesAsync(filePath, [buildContext, filePath](std::vector<uint8_t>&& data) {
+                    if (data.empty())
+                    {
+                        buildContext->TotalProcessed++;
+                        buildContext->FinishedCount++;
+                        return;
+                    }
+
+                    auto* work = new WorkRequest();
+                    work->path = filePath;
+                    work->data = std::move(data);
+                    work->context = buildContext;
+                    work->req.data = work;
+
+                    uv_queue_work(
+                        OpenRCT2::Platform::LibuvLoop::Get().GetLoop(), &work->req,
+                        [](uv_work_t* req_inner) {
+                            auto* work_inner = static_cast<WorkRequest*>(req_inner->data);
+                            work_inner->item = work_inner->context->Index->Create(
+                                work_inner->context->Language, work_inner->path, std::move(work_inner->data));
+                        },
+                        [](uv_work_t* req_inner, int status) {
+                            auto* work_inner = static_cast<WorkRequest*>(req_inner->data);
+                            if (work_inner->item.has_value())
+                            {
+                                std::lock_guard lock(work_inner->context->AllItemsMutex);
+                                work_inner->context->AllItems.push_back(std::move(work_inner->item.value()));
+                            }
+                            work_inner->context->TotalProcessed++;
+                            work_inner->context->FinishedCount++;
+                            delete work_inner;
+                        });
+                });
+            }
+
+            while (finishedCount.load() < totalCount)
+            {
+                OpenRCT2::GetContext()->SetProgress(
+                    static_cast<uint32_t>(totalProcessed.load()), static_cast<uint32_t>(totalCount));
+                OpenRCT2::Platform::LibuvLoop::Get().Tick();
+                OpenRCT2::Platform::Sleep(1);
+            }
+#else
             JobPool jobPool;
             std::mutex mtx;
             std::atomic<size_t> processed{ 0 };
@@ -202,6 +301,7 @@ private:
             jobPool.Join([&]() {
                 OpenRCT2::GetContext()->SetProgress(static_cast<uint32_t>(processed.load()), static_cast<uint32_t>(totalCount));
             });
+#endif
         }
 
         WriteIndexFile(language, scanResult.Stats, allItems);

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -13,6 +13,11 @@
 
 namespace OpenRCT2::Path
 {
+    // Prevent the Win32 CreateDirectory macro from rewriting this symbol to CreateDirectoryW.
+#ifdef CreateDirectory
+    #undef CreateDirectory
+#endif
+
     [[nodiscard]] u8string Combine(u8string_view a, u8string_view b);
 
     template<typename... Args>

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -1113,6 +1113,7 @@
     <ClCompile Include="peep\RideUseSystem.cpp" />
     <ClCompile Include="PlatformEnvironment.cpp" />
     <ClCompile Include="platform\Crash.cpp" />
+    <ClCompile Include="platform\LibuvLoop.cpp" />
     <ClCompile Include="platform\Platform.Android.cpp" />
     <ClCompile Include="platform\Platform.Common.cpp" />
     <ClCompile Include="platform\Platform.Linux.cpp" />

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -489,6 +489,69 @@ namespace OpenRCT2::ObjectFactory
         return nullptr;
     }
 
+    std::unique_ptr<Object> CreateObjectFromData(u8string_view path, std::vector<uint8_t>&& data, bool loadImages)
+    {
+        std::unique_ptr<Object> object;
+        auto extension = Path::GetExtension(path);
+        if (String::iequals(extension, ".json"))
+        {
+            try
+            {
+                json_t jRoot = Json::FromVector(data);
+                auto fileDataRetriever = FileSystemDataRetriever(Path::GetDirectory(path));
+                object = CreateObjectFromJson(jRoot, &fileDataRetriever, loadImages, path);
+            }
+            catch (const std::exception& e)
+            {
+                Console::Error::WriteLine("Unable to read JSON from '%s': %s", u8string(path).c_str(), e.what());
+            }
+        }
+        else if (String::iequals(extension, ".parkobj"))
+        {
+            // For .parkobj, we still need to open the zip, which we can do from memory if needed,
+            // but for now, let's just use the file path since Zip::Open might not support memory yet.
+            object = CreateObjectFromZipFile(path, loadImages);
+        }
+        else
+        {
+            // Legacy DAT
+            try
+            {
+                auto chunkStream = MemoryStream(data.data(), data.size());
+                auto fs = chunkStream; // Mocked as IStream
+                auto chunkReader = SawyerChunkReader(&fs);
+
+                RCTObjectEntry entry = fs.ReadValue<RCTObjectEntry>();
+
+                if (entry.GetType() != ObjectType::scenarioMeta)
+                {
+                    object = CreateObject(entry.GetType());
+                    object->SetDescriptor(ObjectEntryDescriptor(entry));
+                    object->SetFileName(Path::GetFileNameWithoutExtension(path));
+
+                    utf8 objectName[kDatNameLength + 1] = { 0 };
+                    ObjectEntryGetNameFixed(objectName, sizeof(objectName), &entry);
+
+                    auto chunk = chunkReader.ReadChunk();
+                    auto innerChunkStream = MemoryStream(chunk->GetData(), chunk->GetLength());
+                    auto readContext = ReadObjectContext(objectName, loadImages, nullptr);
+                    ReadObjectLegacy(*object, &readContext, &innerChunkStream);
+                    if (readContext.WasError())
+                    {
+                        throw std::runtime_error("Object has errors");
+                    }
+                    object->SetSourceGames({ entry.GetSourceGame() });
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERROR("Error: %s when processing object %s from data", e.what(), u8string(path).c_str());
+            }
+        }
+
+        return object;
+    }
+
     static void ExtractSourceGames(const std::string& id, json_t& jRoot, Object& result)
     {
         auto sourceGames = jRoot["sourceGame"];

--- a/src/openrct2/object/ObjectFactory.h
+++ b/src/openrct2/object/ObjectFactory.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string_view>
+#include <vector>
 
 namespace OpenRCT2
 {
@@ -32,4 +33,6 @@ namespace OpenRCT2::ObjectFactory
     [[nodiscard]] std::unique_ptr<Object> CreateObject(ObjectType type);
 
     [[nodiscard]] std::unique_ptr<Object> CreateObjectFromJsonFile(const std::string& path, bool loadImages);
+    [[nodiscard]] std::unique_ptr<Object> CreateObjectFromData(
+        u8string_view path, std::vector<uint8_t>&& data, bool loadImages);
 } // namespace OpenRCT2::ObjectFactory

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -122,6 +122,36 @@ namespace OpenRCT2
             return item;
         }
 
+        std::optional<ObjectRepositoryItem> Create(
+            [[maybe_unused]] int32_t language, const std::string& path, std::vector<uint8_t>&& data) const override
+        {
+            std::unique_ptr<Object> object = ObjectFactory::CreateObjectFromData(path, std::move(data), false);
+
+            // All official DAT files have a JSON object counterpart. Avoid loading the obsolete .DAT versions,
+            // which can happen if the user copies the official DAT objects to their custom content folder.
+            if (object == nullptr
+                || (object->GetGeneration() == ObjectGeneration::DAT
+                    && object->GetObjectEntry().GetSourceGame() != ObjectSourceGame::custom))
+            {
+                return std::nullopt;
+            }
+
+            ObjectRepositoryItem item = {};
+            item.Type = object->GetObjectType();
+            item.Generation = object->GetGeneration();
+            item.Identifier = object->GetIdentifier();
+            item.ObjectEntry = object->GetObjectEntry();
+            item.Version = object->GetVersion();
+            item.Path = path;
+            item.Name = object->GetName();
+            item.Authors = object->GetAuthors();
+            item.Sources = object->GetSourceGames();
+            if (object->IsCompatibilityObject())
+                item.Flags |= ObjectItemFlags::IsCompatibilityObject;
+            object->SetRepositoryItem(&item);
+            return item;
+        }
+
     protected:
         void Serialise(DataSerialiser& ds, const ObjectRepositoryItem& item) const override
         {

--- a/src/openrct2/platform/LibuvLoop.cpp
+++ b/src/openrct2/platform/LibuvLoop.cpp
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef USE_LIBUV
+    #include "LibuvLoop.h"
+
+    #include "../Diagnostic.h"
+
+    #include <uv.h>
+
+namespace OpenRCT2::Platform
+{
+    LibuvLoop::LibuvLoop()
+    {
+        _loop = uv_default_loop();
+        if (_loop == nullptr)
+        {
+            LOG_FATAL("Unable to initialize libuv default loop.");
+        }
+    }
+
+    LibuvLoop::~LibuvLoop()
+    {
+        // uv_loop_close(_loop); // The default loop should not be closed manually until exit
+    }
+
+    LibuvLoop& LibuvLoop::Get()
+    {
+        static LibuvLoop instance;
+        return instance;
+    }
+
+    void LibuvLoop::Tick()
+    {
+        uv_run(_loop, UV_RUN_NOWAIT);
+    }
+} // namespace OpenRCT2::Platform
+#endif

--- a/src/openrct2/platform/LibuvLoop.h
+++ b/src/openrct2/platform/LibuvLoop.h
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef USE_LIBUV
+    #include <uv.h>
+
+namespace OpenRCT2::Platform
+{
+    class LibuvLoop
+    {
+    private:
+        uv_loop_t* _loop;
+
+    public:
+        LibuvLoop();
+        ~LibuvLoop();
+
+        static LibuvLoop& Get();
+
+        uv_loop_t* GetLoop() const
+        {
+            return _loop;
+        }
+
+        void Tick();
+    };
+} // namespace OpenRCT2::Platform
+#endif

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -270,7 +270,8 @@ namespace OpenRCT2::Platform
             steamroot, downloadDepotFolder, "app_" + std::to_string(data.appId), "depot_" + std::to_string(data.depotId));
     }
 
-    void ReadAllBytesAsync([[maybe_unused]] u8string_view path, [[maybe_unused]] std::function<void(std::vector<uint8_t>&&)> callback)
+    void ReadAllBytesAsync(
+        [[maybe_unused]] u8string_view path, [[maybe_unused]] std::function<void(std::vector<uint8_t>&&)> callback)
     {
 #if defined(USE_LIBUV) && !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
         struct ReadRequest
@@ -317,12 +318,13 @@ namespace OpenRCT2::Platform
 
                 auto size = stat_req->statbuf.st_size;
                 req_inner2->data.resize(size);
-                req_inner2->buffer = uv_buf_init(reinterpret_cast<char*>(req_inner2->data.data()), static_cast<unsigned int>(size));
+                req_inner2->buffer = uv_buf_init(
+                    reinterpret_cast<char*>(req_inner2->data.data()), static_cast<unsigned int>(size));
 
                 req_inner2->read_req.data = req_inner2;
                 uv_fs_read(
-                    stat_req->loop, &req_inner2->read_req, static_cast<uv_file>(req_inner2->open_req.result), &req_inner2->buffer,
-                    1, 0, [](uv_fs_t* read_req) {
+                    stat_req->loop, &req_inner2->read_req, static_cast<uv_file>(req_inner2->open_req.result),
+                    &req_inner2->buffer, 1, 0, [](uv_fs_t* read_req) {
                         auto* req_inner3 = static_cast<ReadRequest*>(read_req->data);
                         if (read_req->result < 0)
                         {

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "../Date.h"
+#include "../Diagnostic.h"
 
 #ifdef _WIN32
     #ifndef WIN32_LEAN_AND_MEAN
@@ -31,6 +32,7 @@
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
 #include "../localisation/Currency.h"
+#include "LibuvLoop.h"
 #include "Platform.h"
 
 #include <algorithm>
@@ -266,6 +268,95 @@ namespace OpenRCT2::Platform
     {
         return Path::Combine(
             steamroot, downloadDepotFolder, "app_" + std::to_string(data.appId), "depot_" + std::to_string(data.depotId));
+    }
+
+    void ReadAllBytesAsync([[maybe_unused]] u8string_view path, [[maybe_unused]] std::function<void(std::vector<uint8_t>&&)> callback)
+    {
+#if defined(USE_LIBUV) && !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
+        struct ReadRequest
+        {
+            uv_fs_t open_req;
+            uv_fs_t read_req;
+            uv_fs_t stat_req;
+            uv_fs_t close_req;
+            uv_buf_t buffer;
+            std::vector<uint8_t> data;
+            std::function<void(std::vector<uint8_t>&&)> callback;
+            std::string path;
+        };
+
+        auto* req = new ReadRequest();
+        req->callback = std::move(callback);
+        req->path = std::string(path);
+
+        auto on_open = [](uv_fs_t* open_req) {
+            auto* req_inner = static_cast<ReadRequest*>(open_req->data);
+            if (open_req->result < 0)
+            {
+                LOG_VERBOSE("Libuv error opening file: %s", uv_strerror(static_cast<int>(open_req->result)));
+                req_inner->callback({});
+                uv_fs_req_cleanup(open_req);
+                delete req_inner;
+                return;
+            }
+
+            req_inner->stat_req.data = req_inner;
+            uv_fs_fstat(open_req->loop, &req_inner->stat_req, static_cast<uv_file>(open_req->result), [](uv_fs_t* stat_req) {
+                auto* req_inner2 = static_cast<ReadRequest*>(stat_req->data);
+                if (stat_req->result < 0)
+                {
+                    LOG_VERBOSE("Libuv error stating file: %s", uv_strerror(static_cast<int>(stat_req->result)));
+                    uv_fs_close(
+                        stat_req->loop, &req_inner2->close_req, static_cast<uv_file>(req_inner2->open_req.result), nullptr);
+                    req_inner2->callback({});
+                    uv_fs_req_cleanup(&req_inner2->open_req);
+                    uv_fs_req_cleanup(stat_req);
+                    delete req_inner2;
+                    return;
+                }
+
+                auto size = stat_req->statbuf.st_size;
+                req_inner2->data.resize(size);
+                req_inner2->buffer = uv_buf_init(reinterpret_cast<char*>(req_inner2->data.data()), static_cast<unsigned int>(size));
+
+                req_inner2->read_req.data = req_inner2;
+                uv_fs_read(
+                    stat_req->loop, &req_inner2->read_req, static_cast<uv_file>(req_inner2->open_req.result), &req_inner2->buffer,
+                    1, 0, [](uv_fs_t* read_req) {
+                        auto* req_inner3 = static_cast<ReadRequest*>(read_req->data);
+                        if (read_req->result < 0)
+                        {
+                            LOG_VERBOSE("Libuv error reading file: %s", uv_strerror(static_cast<int>(read_req->result)));
+                            req_inner3->callback({});
+                        }
+                        else
+                        {
+                            req_inner3->callback(std::move(req_inner3->data));
+                        }
+
+                        uv_fs_close(
+                            read_req->loop, &req_inner3->close_req, static_cast<uv_file>(req_inner3->open_req.result), nullptr);
+                        uv_fs_req_cleanup(&req_inner3->open_req);
+                        uv_fs_req_cleanup(&req_inner3->stat_req);
+                        uv_fs_req_cleanup(read_req);
+                        uv_fs_req_cleanup(&req_inner3->close_req);
+                        delete req_inner3;
+                    });
+            });
+        };
+
+        req->open_req.data = req;
+        uv_fs_open(LibuvLoop::Get().GetLoop(), &req->open_req, req->path.c_str(), O_RDONLY, 0, on_open);
+#else
+        try
+        {
+            callback(File::ReadAllBytes(path));
+        }
+        catch (const std::exception&)
+        {
+            callback({});
+        }
+#endif
     }
 
     bool triggerSteamDownload()

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -255,7 +255,6 @@ namespace OpenRCT2::Platform
     }
     #endif
 
-
     bool ShouldIgnoreCase()
     {
         return false;

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -255,6 +255,7 @@ namespace OpenRCT2::Platform
     }
     #endif
 
+
     bool ShouldIgnoreCase()
     {
         return false;

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -15,6 +15,7 @@
 
 #include <bit>
 #include <ctime>
+#include <functional>
 #include <optional>
 #include <sfl/static_vector.hpp>
 #include <vector>
@@ -145,6 +146,7 @@ namespace OpenRCT2::Platform
     bool IsPathSeparator(char c);
     uint64_t GetLastModified(std::string_view path);
     uint64_t GetFileSize(std::string_view path);
+    void ReadAllBytesAsync(u8string_view path, std::function<void(std::vector<uint8_t>&&)> callback);
     std::string ResolveCasing(std::string_view path, bool fileExists);
     std::string SanitiseFilename(std::string_view originalName);
     bool IsFilenameValid(u8string_view fileName);

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -68,6 +68,12 @@ namespace OpenRCT2::RCT1
             return true;
         }
 
+        bool LoadFromData(std::vector<uint8_t>&& data) override
+        {
+            auto stream = MemoryStream(data.data(), data.size());
+            return LoadFromStream(&stream);
+        }
+
         std::unique_ptr<TrackDesign> Import() override
         {
             std::unique_ptr<TrackDesign> td = std::make_unique<TrackDesign>();

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1095,3 +1095,4 @@ namespace OpenRCT2::RCT2
 } // namespace OpenRCT2::RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);
+std::vector<uint8_t> DecryptSea(const std::vector<uint8_t>& data, std::string_view filename);

--- a/src/openrct2/rct2/SeaDecrypt.cpp
+++ b/src/openrct2/rct2/SeaDecrypt.cpp
@@ -85,15 +85,21 @@ static void Decrypt(std::vector<uint8_t>& data, const EncryptionKey& key)
 
 std::vector<uint8_t> DecryptSea(const fs::path& path)
 {
-    auto key = GetEncryptionKey(path.filename().u8string());
     auto data = File::ReadAllBytes(path.u8string());
+    return DecryptSea(data, path.filename().u8string());
+}
+
+std::vector<uint8_t> DecryptSea(const std::vector<uint8_t>& data, std::string_view filename)
+{
+    auto key = GetEncryptionKey(filename);
+    auto decrypted = data;
 
     // Last 4 bytes is the checksum
-    size_t inputSize = data.size() - 4;
-    uint32_t checksum;
-    std::memcpy(&checksum, data.data() + inputSize, sizeof(checksum));
-    data.resize(inputSize);
+    if (decrypted.size() < 4)
+        return decrypted;
+    size_t inputSize = decrypted.size() - 4;
+    decrypted.resize(inputSize);
 
-    Decrypt(data, key);
-    return data;
+    Decrypt(decrypted, key);
+    return decrypted;
 }

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -165,6 +165,12 @@ namespace OpenRCT2::RCT2
             return true;
         }
 
+        bool LoadFromData(std::vector<uint8_t>&& data) override
+        {
+            auto stream = MemoryStream(data.data(), data.size());
+            return LoadFromStream(&stream);
+        }
+
         std::unique_ptr<TrackDesign> Import() override
         {
             std::unique_ptr<TrackDesign> td = std::make_unique<TrackDesign>();

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -620,6 +620,21 @@ std::unique_ptr<TrackDesign> TrackDesignImport(const utf8* path)
     return nullptr;
 }
 
+std::unique_ptr<TrackDesign> TrackDesignImportFromData(u8string_view path, std::vector<uint8_t>&& data)
+{
+    try
+    {
+        auto trackImporter = TrackImporter::Create(std::string(path));
+        trackImporter->LoadFromData(std::move(data));
+        return trackImporter->Import();
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR("Unable to load track design from data: %s", e.what());
+    }
+    return nullptr;
+}
+
 /**
  *
  *  rct2: 0x006ABDB0

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -237,6 +237,7 @@ extern bool gTrackDesignSaveMode;
 extern RideId gTrackDesignSaveRideIndex;
 
 [[nodiscard]] std::unique_ptr<TrackDesign> TrackDesignImport(const utf8* path);
+[[nodiscard]] std::unique_ptr<TrackDesign> TrackDesignImportFromData(u8string_view path, std::vector<uint8_t>&& data);
 
 void TrackDesignMirror(TrackDesign& td);
 

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -92,6 +92,26 @@ public:
         return std::nullopt;
     }
 
+    std::optional<TrackRepositoryItem> Create(int32_t, const std::string& path, std::vector<uint8_t>&& data) const override
+    {
+        auto td = TrackDesignImportFromData(path, std::move(data));
+        if (td != nullptr)
+        {
+            TrackRepositoryItem item{};
+            item.Name = GetNameFromTrackPath(path);
+            item.Path = path;
+            item.RideType = td->trackAndVehicle.rtdIndex;
+            item.ObjectEntry = std::string(td->trackAndVehicle.vehicleObject.Entry.name, 8);
+            if (IsTrackReadOnly(path))
+            {
+                item.flags.set(TrackRepoItemFlag::readOnly);
+            }
+            return item;
+        }
+
+        return std::nullopt;
+    }
+
 protected:
     void Serialise(DataSerialiser& ds, const TrackRepositoryItem& item) const override
     {

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -155,6 +155,19 @@ protected:
         return std::nullopt;
     }
 
+    std::optional<ScenarioIndexEntry> Create(
+        int32_t language, const std::string& path, std::vector<uint8_t>&& data) const override
+    {
+        ScenarioIndexEntry entry;
+        auto timestamp = File::GetLastModified(path);
+        if (GetScenarioInfoFromData(path, std::move(data), timestamp, &entry))
+        {
+            return entry;
+        }
+
+        return std::nullopt;
+    }
+
     void Serialise(DataSerialiser& ds, const ScenarioIndexEntry& item) const override
     {
         ds << item.Path;
@@ -197,6 +210,70 @@ private:
 
         auto fs = std::make_unique<FileStream>(path, FileMode::open);
         return fs;
+    }
+
+    /**
+     * Reads basic information from a scenario file data.
+     */
+    static bool GetScenarioInfoFromData(
+        const std::string& path, std::vector<uint8_t>&& data, uint64_t timestamp, ScenarioIndexEntry* entry)
+    {
+        LOG_VERBOSE("GetScenarioInfoFromData(%s, ..., %d, ...)", path.c_str(), timestamp);
+
+        try
+        {
+            auto& objRepository = GetContext()->GetObjectRepository();
+            std::unique_ptr<IParkImporter> importer;
+            std::string extension = Path::GetExtension(path);
+
+            auto stream = MemoryStream(data.data(), data.size());
+
+            if (String::iequals(extension, ".park"))
+            {
+                importer = ParkImporter::CreateParkFile(objRepository);
+                importer->LoadFromStream(&stream, true, true);
+            }
+            else if (String::iequals(extension, ".sc4"))
+            {
+                importer = ParkImporter::CreateS4();
+                importer->LoadFromStream(&stream, true, true);
+            }
+            else
+            {
+                importer = ParkImporter::CreateS6(objRepository);
+                // Handle .sea decryption if needed, but here we expect data to be already decrypted if it was .sea?
+                // Actually GetStreamFromRCT2Scenario handles .sea by reading file.
+                // If it's .sea, we should have decrypted it before calling this or handle it here.
+                if (String::iequals(extension, ".sea"))
+                {
+                    auto decryptedData = DecryptSea(data, Path::GetFileName(path));
+                    auto decryptedStream = MemoryStream(decryptedData.data(), decryptedData.size());
+                    importer->LoadFromStream(&decryptedStream, true, true);
+                }
+                else
+                {
+                    importer->LoadFromStream(&stream, true, true);
+                }
+            }
+
+            if (importer)
+            {
+                if (importer->PopulateIndexEntry(entry))
+                {
+                    entry->Path = path;
+                    entry->Timestamp = timestamp;
+                    return true;
+                }
+            }
+
+            LOG_VERBOSE("%s is not a scenario", path.c_str());
+            return false;
+        }
+        catch (const std::exception&)
+        {
+            Console::Error::WriteLine("Unable to read scenario from data: '%s'", path.c_str());
+        }
+        return false;
     }
 
     /**

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -17,6 +17,11 @@
 #include <string>
 #include <vector>
 
+// Undefine Windows macros that conflict with our functions
+#ifdef CreateWindow
+    #undef CreateWindow
+#endif
+
 struct ScreenCoordsXY;
 struct ITitleSequencePlayer;
 

--- a/test/tests/Platform.cpp
+++ b/test/tests/Platform.cpp
@@ -7,7 +7,9 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <fstream>
 #include <gtest/gtest.h>
+#include <openrct2/platform/LibuvLoop.h>
 #include <openrct2/platform/Platform.h>
 
 using namespace OpenRCT2;
@@ -23,4 +25,39 @@ TEST(platform, sanitise_filename)
 #else
     ASSERT_EQ("forbidden_______chars", Platform::SanitiseFilename("forbidden/\\:\"|?*chars"));
 #endif
+}
+
+TEST(platform, read_all_bytes_async)
+{
+    const std::string testFile = "test_async.bin";
+    const std::vector<uint8_t> testData = { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04 };
+
+    // Create test file
+    std::ofstream ofs(testFile, std::ios::binary);
+    ofs.write(reinterpret_cast<const char*>(testData.data()), testData.size());
+    ofs.close();
+
+    bool done = false;
+    std::vector<uint8_t> readData;
+    Platform::ReadAllBytesAsync(testFile, [&](std::vector<uint8_t>&& data) {
+        readData = std::move(data);
+        done = true;
+    });
+
+    // Tick the loop
+    int iterations = 0;
+    while (!done && iterations < 1000)
+    {
+#ifdef USE_LIBUV
+        Platform::LibuvLoop::Get().Tick();
+#endif
+        Platform::Sleep(1);
+        iterations++;
+    }
+
+    EXPECT_TRUE(done);
+    EXPECT_EQ(testData, readData);
+
+    // Cleanup
+    std::remove(testFile.c_str());
 }


### PR DESCRIPTION
This change integrates libuv into OpenRCT2 to enable event-driven asset loading. It implements a LibuvLoop singleton integrated into the game's tick loop, adds Platform::ReadAllBytesAsync for non-blocking file I/O, and refactors FileIndex::Build to parallelize asset parsing using uv_queue_work. Overloads were added to ObjectFactory, TrackImporter, and asset repositories to support direct creation from memory buffers. This improvement is expected to enhance initial loading performance, particularly on Windows.

---
*PR created automatically by Jules for task [11730459764675755331](https://jules.google.com/task/11730459764675755331) started by @janisozaur*