### PR TITLE
Fix image leak when exiting toolbox menus

### DIFF
--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -147,6 +147,11 @@ namespace OpenRCT2
         return !(*this == rhs);
     }
 
+    Object::~Object()
+    {
+        UnloadImages();
+    }
+
     void* Object::GetLegacyData()
     {
         throw std::runtime_error("Not supported.");

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -173,8 +173,8 @@ namespace OpenRCT2
         std::string _identifier;
         ObjectVersion _version;
         ObjectEntryDescriptor _descriptor{};
-        StringTable _stringTable;
-        ImageTable _imageTable;
+        StringTable _stringTable{};
+        ImageTable _imageTable{};
         std::vector<ObjectSourceGame> _sourceGames;
         std::vector<std::string> _authors;
         ObjectGeneration _generation{};
@@ -205,7 +205,7 @@ namespace OpenRCT2
         std::string GetString(int32_t language, ObjectStringID index) const;
 
     public:
-        virtual ~Object() = default;
+        virtual ~Object();
 
         std::string_view GetIdentifier() const
         {

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -349,6 +349,23 @@ namespace OpenRCT2
                     list.clear();
                 }
             }
+
+            // Also unload everything in the repository that might have been loaded but not assigned a slot
+            const size_t numObjects = _objectRepository.GetNumObjects();
+            const ObjectRepositoryItem* items = _objectRepository.GetObjects();
+            for (size_t i = 0; i < numObjects; i++)
+            {
+                const auto& item = items[i];
+                if (item.LoadedObject != nullptr)
+                {
+                    if (!onlyTransient || !IsIntransientObjectType(item.Type))
+                    {
+                        item.LoadedObject->Unload();
+                        _objectRepository.UnregisterLoadedObject(&item, item.LoadedObject.get());
+                    }
+                }
+            }
+
             UpdateSceneryGroupIndexes();
             ResetTypeToRideEntryIndexMap();
         }
@@ -483,6 +500,26 @@ namespace OpenRCT2
                         {
                             UnloadObject(object);
                             object = nullptr;
+                            numObjectsUnloaded++;
+                        }
+                    }
+                }
+            }
+
+            // Also unload everything in the repository that is not in the exceptSet
+            const size_t numRepoObjects = _objectRepository.GetNumObjects();
+            const ObjectRepositoryItem* repoItems = _objectRepository.GetObjects();
+            for (size_t i = 0; i < numRepoObjects; i++)
+            {
+                const auto& item = repoItems[i];
+                if (item.LoadedObject != nullptr)
+                {
+                    if (!IsIntransientObjectType(item.Type))
+                    {
+                        if (exceptSet.find(item.LoadedObject.get()) == exceptSet.end())
+                        {
+                            item.LoadedObject->Unload();
+                            _objectRepository.UnregisterLoadedObject(&item, item.LoadedObject.get());
                             numObjectsUnloaded++;
                         }
                     }

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -485,6 +485,10 @@ namespace OpenRCT2
             // Unload objects that are not in the hash set
             size_t totalObjectsLoaded = 0;
             size_t numObjectsUnloaded = 0;
+
+            // Track unique objects to avoid double counting for logging
+            std::unordered_set<Object*> uniqueObjects;
+
             for (auto type : getAllObjectTypes())
             {
                 if (!IsIntransientObjectType(type))
@@ -495,7 +499,8 @@ namespace OpenRCT2
                         if (object == nullptr)
                             continue;
 
-                        totalObjectsLoaded++;
+                        uniqueObjects.insert(object);
+
                         if (exceptSet.find(object) == exceptSet.end())
                         {
                             UnloadObject(object);
@@ -516,6 +521,8 @@ namespace OpenRCT2
                 {
                     if (!IsIntransientObjectType(item.Type))
                     {
+                        uniqueObjects.insert(item.LoadedObject.get());
+
                         if (exceptSet.find(item.LoadedObject.get()) == exceptSet.end())
                         {
                             item.LoadedObject->Unload();
@@ -525,6 +532,8 @@ namespace OpenRCT2
                     }
                 }
             }
+
+            totalObjectsLoaded = uniqueObjects.size();
 
             LOG_VERBOSE("%u / %u objects unloaded", numObjectsUnloaded, totalObjectsLoaded);
         }


### PR DESCRIPTION
Investigated and fixed a resource leak where image slots were not freed when exiting the Track Designer or Track Designs Manager.

The leak was caused by objects being loaded into memory (specifically the `ObjectRepository`) for previews or management, but not being assigned to any of the game's active object "slots" managed by `ObjectManager`. When the game performed cleanup (e.g., returning to the title screen), it only iterated over these slots, leaving objects in the repository orphaned and their allocated images leaked.

Changes:
- Added a virtual destructor to the `Object` base class that calls `UnloadImages()`. This ensures that even if an object is destroyed without an explicit `Unload()` call, its images are freed.
- Enhanced `ObjectManager::UnloadAll` and `ObjectManager::UnloadObjectsExcept` to explicitly iterate through and unload all objects currently registered in the `ObjectRepository`. This ensures that transient objects used for previews are correctly cleaned up.

---
*PR created automatically by Jules for task [6841871346823710623](https://jules.google.com/task/6841871346823710623) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured object resources (such as loaded images) are released when objects are destroyed, reducing memory leaks.
  * Improved unloading logic to more reliably detect and release unused loaded objects, with de-duplication to provide accurate unload accounting and reduce leftover memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->