### PR TITLE
Fix InvalidationGrid data race by deferring UI intents to the main thread

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -163,8 +163,14 @@ namespace OpenRCT2
 
         BackgroundWorker _backgroundWorker;
 
+        struct QueuedIntent
+        {
+            Intent intent;
+            bool isBroadcast;
+        };
+
         std::mutex _intentQueueMutex;
-        std::queue<Intent> _intentQueue;
+        std::queue<QueuedIntent> _intentQueue;
 
     public:
         // Singleton of Context.
@@ -712,16 +718,7 @@ namespace OpenRCT2
             auto captionString = _localisationService->GetString(captionStringId);
             auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
             intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
-
-            if (_mainThreadId == std::this_thread::get_id())
-            {
-                ContextOpenIntent(&intent);
-            }
-            else
-            {
-                std::lock_guard<std::mutex> lock(_intentQueueMutex);
-                _intentQueue.push(std::move(intent));
-            }
+            ContextOpenIntent(&intent);
         }
 
         void SetProgress(uint32_t currentProgress, uint32_t totalCount, StringId format = kStringIdNone) override
@@ -735,40 +732,22 @@ namespace OpenRCT2
             intent.PutExtra(INTENT_EXTRA_PROGRESS_OFFSET, currentProgress);
             intent.PutExtra(INTENT_EXTRA_PROGRESS_TOTAL, totalCount);
             intent.PutExtra(INTENT_EXTRA_STRING_ID, format);
+            ContextOpenIntent(&intent);
 
-            const auto isMainThread = _mainThreadId == std::this_thread::get_id();
-            if (isMainThread)
+            // When we call this from the main thread we can pump messages and redraw.
+            if (!gOpenRCT2Headless && IsMainThread())
             {
-                ContextOpenIntent(&intent);
-
-                // When we call this from the main thread we can pump messages and redraw.
-                if (!gOpenRCT2Headless)
-                {
-                    _uiContext->ProcessMessages();
-                    auto* windowMgr = GetWindowManager();
-                    windowMgr->InvalidateByClass(WindowClass::progressWindow);
-                    Draw();
-                }
-            }
-            else
-            {
-                std::lock_guard<std::mutex> lock(_intentQueueMutex);
-                _intentQueue.push(std::move(intent));
+                _uiContext->ProcessMessages();
+                auto* windowMgr = GetWindowManager();
+                windowMgr->InvalidateByClass(WindowClass::progressWindow);
+                Draw();
             }
         }
 
         void CloseProgress() override
         {
             auto intent = Intent(INTENT_ACTION_PROGRESS_CLOSE);
-            if (_mainThreadId == std::this_thread::get_id())
-            {
-                ContextOpenIntent(&intent);
-            }
-            else
-            {
-                std::lock_guard<std::mutex> lock(_intentQueueMutex);
-                _intentQueue.push(std::move(intent));
-            }
+            ContextOpenIntent(&intent);
         }
 
         bool LoadParkFromFile(const u8string& path, bool loadTitleScreenOnFail = false, bool asScenario = false) final override
@@ -1469,11 +1448,18 @@ namespace OpenRCT2
                 std::unique_lock<std::mutex> lock(_intentQueueMutex);
                 while (!_intentQueue.empty())
                 {
-                    Intent intent = std::move(_intentQueue.front());
+                    QueuedIntent queuedIntent = std::move(_intentQueue.front());
                     _intentQueue.pop();
                     lock.unlock();
 
-                    ContextOpenIntent(&intent);
+                    if (queuedIntent.isBroadcast)
+                    {
+                        ContextBroadcastIntent(&queuedIntent.intent);
+                    }
+                    else
+                    {
+                        ContextOpenIntent(&queuedIntent.intent);
+                    }
 
                     lock.lock();
                 }
@@ -1643,6 +1629,17 @@ namespace OpenRCT2
         {
             return _backgroundWorker;
         }
+
+        bool IsMainThread() const override
+        {
+            return _mainThreadId == std::this_thread::get_id();
+        }
+
+        void EnqueueIntent(const Intent& intent, bool isBroadcast) override
+        {
+            std::lock_guard<std::mutex> lock(_intentQueueMutex);
+            _intentQueue.push({ intent, isBroadcast });
+        }
     };
 
     Context* Context::Instance = nullptr;
@@ -1802,14 +1799,28 @@ namespace OpenRCT2
 
     WindowBase* ContextOpenIntent(Intent* intent)
     {
-        auto windowManager = GetWindowManager();
-        return windowManager->OpenIntent(intent);
+        auto context = GetContext();
+        if (context->IsMainThread())
+        {
+            auto windowManager = GetWindowManager();
+            return windowManager->OpenIntent(intent);
+        }
+
+        context->EnqueueIntent(*intent, false);
+        return nullptr;
     }
 
     void ContextBroadcastIntent(Intent* intent)
     {
-        auto windowManager = GetWindowManager();
-        windowManager->BroadcastIntent(*intent);
+        auto context = GetContext();
+        if (context->IsMainThread())
+        {
+            auto windowManager = GetWindowManager();
+            windowManager->BroadcastIntent(*intent);
+            return;
+        }
+
+        context->EnqueueIntent(*intent, true);
     }
 
     void ContextForceCloseWindowByClass(WindowClass windowClass)

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -84,6 +84,8 @@
 #include <future>
 #include <iterator>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <string>
 
 using namespace OpenRCT2;
@@ -160,6 +162,9 @@ namespace OpenRCT2
         Timer _forcedUpdateTimer;
 
         BackgroundWorker _backgroundWorker;
+
+        std::mutex _intentQueueMutex;
+        std::queue<Intent> _intentQueue;
 
     public:
         // Singleton of Context.
@@ -707,7 +712,16 @@ namespace OpenRCT2
             auto captionString = _localisationService->GetString(captionStringId);
             auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
             intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
-            ContextOpenIntent(&intent);
+
+            if (_mainThreadId == std::this_thread::get_id())
+            {
+                ContextOpenIntent(&intent);
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(_intentQueueMutex);
+                _intentQueue.push(std::move(intent));
+            }
         }
 
         void SetProgress(uint32_t currentProgress, uint32_t totalCount, StringId format = kStringIdNone) override
@@ -721,24 +735,40 @@ namespace OpenRCT2
             intent.PutExtra(INTENT_EXTRA_PROGRESS_OFFSET, currentProgress);
             intent.PutExtra(INTENT_EXTRA_PROGRESS_TOTAL, totalCount);
             intent.PutExtra(INTENT_EXTRA_STRING_ID, format);
-            ContextOpenIntent(&intent);
 
-            // When we call this from the main thread we can pump messages and redraw.
             const auto isMainThread = _mainThreadId == std::this_thread::get_id();
-
-            if (!gOpenRCT2Headless && isMainThread)
+            if (isMainThread)
             {
-                _uiContext->ProcessMessages();
-                auto* windowMgr = GetWindowManager();
-                windowMgr->InvalidateByClass(WindowClass::progressWindow);
-                Draw();
+                ContextOpenIntent(&intent);
+
+                // When we call this from the main thread we can pump messages and redraw.
+                if (!gOpenRCT2Headless)
+                {
+                    _uiContext->ProcessMessages();
+                    auto* windowMgr = GetWindowManager();
+                    windowMgr->InvalidateByClass(WindowClass::progressWindow);
+                    Draw();
+                }
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(_intentQueueMutex);
+                _intentQueue.push(std::move(intent));
             }
         }
 
         void CloseProgress() override
         {
             auto intent = Intent(INTENT_ACTION_PROGRESS_CLOSE);
-            ContextOpenIntent(&intent);
+            if (_mainThreadId == std::this_thread::get_id())
+            {
+                ContextOpenIntent(&intent);
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(_intentQueueMutex);
+                _intentQueue.push(std::move(intent));
+            }
         }
 
         bool LoadParkFromFile(const u8string& path, bool loadTitleScreenOnFail = false, bool asScenario = false) final override
@@ -1433,6 +1463,21 @@ namespace OpenRCT2
         void Tick()
         {
             PROFILED_FUNCTION();
+
+            // Process any deferred intents from background threads
+            {
+                std::unique_lock<std::mutex> lock(_intentQueueMutex);
+                while (!_intentQueue.empty())
+                {
+                    Intent intent = std::move(_intentQueue.front());
+                    _intentQueue.pop();
+                    lock.unlock();
+
+                    ContextOpenIntent(&intent);
+
+                    lock.lock();
+                }
+            }
 
             // TODO: This variable has been never "variable" in time, some code expects
             // this to be 40Hz (25 ms). Refactor this once the UI is decoupled.

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -144,6 +144,9 @@ namespace OpenRCT2
         virtual float GetTimeScale() const = 0;
 
         virtual BackgroundWorker& GetBackgroundWorker() = 0;
+
+        virtual bool IsMainThread() const = 0;
+        virtual void EnqueueIntent(const Intent& intent, bool isBroadcast) = 0;
     };
 
     [[nodiscard]] std::unique_ptr<IContext> CreateContext();


### PR DESCRIPTION
I have analyzed the TSAN report and confirmed a legitimate data race in the `InvalidationGrid`. The race occurs because `invalidate` is called from background threads (e.g., during preloading/initialization) while `traverseDirtyCells` is running on the main thread for drawing.

To fix this, I have implemented a deferred intent processing mechanism in the `Context` class. UI-related progress updates (`OpenProgress`, `SetProgress`, `CloseProgress`) now detect if they are running on a background thread and, if so, enqueue their actions into a thread-safe queue. This queue is then drained and processed on the main thread at the beginning of each `Context::Tick`.

This ensures that all UI invalidation remains on the main thread, effectively resolving the data race without introducing significant overhead to the hot path.

---
*PR created automatically by Jules for task [5678459532882682434](https://jules.google.com/task/5678459532882682434) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for UI operations and progress dialogs to prevent crashes and instability when multiple threads interact with the application interface simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->