### PR TITLE
Expose zstd and base64 APIs to plugins

### DIFF
--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -249,7 +249,7 @@ target_include_directories(libopenrct2 SYSTEM PRIVATE ${LIBZIP_INCLUDE_DIRS})
 target_include_directories(libopenrct2 SYSTEM PRIVATE ${PNG_INCLUDE_DIRS}
         ${ZLIB_INCLUDE_DIRS})
 target_include_directories(libopenrct2 SYSTEM PRIVATE ${ZSTD_INCLUDE_DIRS})
-include_directories(libopenrct2 SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../thirdparty)
+target_include_directories(libopenrct2 SYSTEM PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../thirdparty)
 
 # To avoid unnecessary rebuilds set the current branch and
 # short sha1 only for the two files that use these

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -17,6 +17,8 @@
     #include "../../../interface/Screenshot.h"
     #include "../../../localisation/Formatting.h"
     #include "../../../object/ObjectManager.h"
+    #include "../../../core/Compression.h"
+    #include "../../../core/MemoryStream.h"
     #include "../../../scenario/Scenario.h"
     #include "../../HookEngine.h"
     #include "../../IconNames.hpp"
@@ -28,6 +30,8 @@
 
     #include <cstdio>
     #include <memory>
+    #include "../../../../thirdparty/base64.hpp"
+    #include <zstd.h>
 
 namespace OpenRCT2::Scripting
 {
@@ -418,6 +422,203 @@ namespace OpenRCT2::Scripting
             return JS_NewInt64(ctx, GetIconByName(iconName));
         }
 
+        static JSValue base64encode(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+        {
+            JSValue data = argv[0];
+            size_t size = 0;
+            uint8_t* bytes = JS_GetUint8Array(ctx, &size, data);
+            if (bytes == nullptr)
+            {
+                return JS_ThrowTypeError(ctx, "Expected Uint8Array");
+            }
+
+            try
+            {
+                std::string encoded = base64::to_base64(std::string_view(reinterpret_cast<const char*>(bytes), size));
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "data", JSFromStdString(ctx, encoded));
+                return obj;
+            }
+            catch (const std::exception& e)
+            {
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 1));
+                JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, e.what()));
+                return obj;
+            }
+        }
+
+        static JSValue base64decode(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+        {
+            JS_UNPACK_STR(str, ctx, argv[0]);
+            try
+            {
+                std::vector<uint8_t> decoded = base64::decode_into<std::vector<uint8_t>>(str);
+                JSValue data = JS_NewUint8ArrayCopy(ctx, decoded.data(), decoded.size());
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "data", data);
+                return obj;
+            }
+            catch (const std::exception& e)
+            {
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 1));
+                JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, e.what()));
+                return obj;
+            }
+        }
+
+        static JSValue zstdCompress(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+        {
+            JSValue data = argv[0];
+            size_t size = 0;
+            uint8_t* bytes = JS_GetUint8Array(ctx, &size, data);
+            if (bytes == nullptr)
+            {
+                return JS_ThrowTypeError(ctx, "Expected Uint8Array");
+            }
+
+            int32_t level = Compression::kZstdDefaultCompressionLevel;
+            if (argc > 1 && JS_IsNumber(argv[1]))
+            {
+                JS_ToInt32(ctx, &level, argv[1]);
+            }
+
+            try
+            {
+                MemoryStream source(bytes, size);
+                MemoryStream dest;
+                if (Compression::zstdCompress(source, size, dest, Compression::ZstdMetadata::both, level))
+                {
+                    JSValue obj = JS_NewObject(ctx);
+                    JS_SetPropertyStr(ctx, obj, "data", JS_NewUint8ArrayCopy(ctx, static_cast<const uint8_t*>(dest.GetData()), dest.GetLength()));
+                    return obj;
+                }
+                else
+                {
+                    JSValue obj = JS_NewObject(ctx);
+                    JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 1));
+                    JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, "Compression failed"));
+                    return obj;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 1));
+                JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, e.what()));
+                return obj;
+            }
+        }
+
+        static JSValue zstdDecompress(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+        {
+            JSValue data = argv[0];
+            size_t size = 0;
+            uint8_t* bytes = JS_GetUint8Array(ctx, &size, data);
+            if (bytes == nullptr)
+            {
+                return JS_ThrowTypeError(ctx, "Expected Uint8Array");
+            }
+
+            int64_t requestedLength = -1;
+            if (argc > 1 && JS_IsNumber(argv[1]))
+            {
+                JS_ToInt64(ctx, &requestedLength, argv[1]);
+            }
+
+            if (requestedLength < -1)
+            {
+                return JS_ThrowRangeError(ctx, "Length must be >= 0 or -1");
+            }
+
+            try
+            {
+                unsigned long long contentSize = ZSTD_getFrameContentSize(bytes, size);
+                if (contentSize == ZSTD_CONTENTSIZE_ERROR)
+                {
+                    JSValue obj = JS_NewObject(ctx);
+                    JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 1));
+                    JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, "Not a valid zstd frame"));
+                    return obj;
+                }
+
+                if (requestedLength == 0)
+                {
+                    JSValue obj = JS_NewObject(ctx);
+                    JS_SetPropertyStr(ctx, obj, "data", JS_NewUint8ArrayCopy(ctx, bytes, 0));
+                    JS_SetPropertyStr(ctx, obj, "moreAvailable", JS_NewBool(ctx, true));
+                    if (contentSize != ZSTD_CONTENTSIZE_UNKNOWN)
+                    {
+                        JS_SetPropertyStr(ctx, obj, "totalSize", JS_NewInt64(ctx, contentSize));
+                    }
+                    return obj;
+                }
+
+                if (requestedLength == -1 && contentSize != ZSTD_CONTENTSIZE_UNKNOWN)
+                {
+                    requestedLength = contentSize;
+                }
+
+                std::vector<uint8_t> outputBuffer;
+                ZSTD_inBuffer input = { bytes, size, 0 };
+                const auto dctxDeleter = [](ZSTD_DCtx* ptr) { ZSTD_freeDCtx(ptr); };
+                std::unique_ptr<ZSTD_DCtx, decltype(dctxDeleter)> dctx(ZSTD_createDCtx(), dctxDeleter);
+                bool moreAvailable = false;
+
+                if (requestedLength != -1)
+                {
+                    outputBuffer.resize(static_cast<size_t>(requestedLength));
+                    ZSTD_outBuffer output = { outputBuffer.data(), outputBuffer.size(), 0 };
+                    size_t const ret = ZSTD_decompressStream(dctx.get(), &output, &input);
+                    if (ZSTD_isError(ret))
+                    {
+                        JSValue obj = JS_NewObject(ctx);
+                        JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 3));
+                        JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, ZSTD_getErrorName(ret)));
+                        return obj;
+                    }
+                    outputBuffer.resize(output.pos);
+                    moreAvailable = (ret > 0) || (input.pos < input.size);
+                }
+                else
+                {
+                    uint8_t temp[16384];
+                    size_t ret;
+                    do
+                    {
+                        ZSTD_outBuffer output = { temp, sizeof(temp), 0 };
+                        ret = ZSTD_decompressStream(dctx.get(), &output, &input);
+                        if (ZSTD_isError(ret))
+                        {
+                            JSValue obj = JS_NewObject(ctx);
+                            JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 3));
+                            JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, ZSTD_getErrorName(ret)));
+                            return obj;
+                        }
+                        outputBuffer.insert(outputBuffer.end(), temp, temp + output.pos);
+                    } while (ret > 0);
+                    moreAvailable = (input.pos < input.size);
+                }
+
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "data", JS_NewUint8ArrayCopy(ctx, outputBuffer.data(), outputBuffer.size()));
+                JS_SetPropertyStr(ctx, obj, "moreAvailable", JS_NewBool(ctx, moreAvailable));
+                if (contentSize != ZSTD_CONTENTSIZE_UNKNOWN)
+                {
+                    JS_SetPropertyStr(ctx, obj, "totalSize", JS_NewInt64(ctx, contentSize));
+                }
+                return obj;
+            }
+            catch (const std::exception& e)
+            {
+                JSValue obj = JS_NewObject(ctx);
+                JS_SetPropertyStr(ctx, obj, "error", JS_NewInt32(ctx, 4));
+                JS_SetPropertyStr(ctx, obj, "message", JSFromStdString(ctx, e.what()));
+                return obj;
+            }
+        }
+
     public:
         void Register(JSContext* ctx)
         {
@@ -444,6 +645,10 @@ namespace OpenRCT2::Scripting
                 JS_CFUNC_DEF("clearInterval", 1, ScContext::clearInterval),
                 JS_CFUNC_DEF("clearTimeout", 1, ScContext::clearTimeout),
                 JS_CFUNC_DEF("getIcon", 1, ScContext::getIcon),
+                JS_CFUNC_DEF("base64encode", 1, ScContext::base64encode),
+                JS_CFUNC_DEF("base64decode", 1, ScContext::base64decode),
+                JS_CFUNC_DEF("zstdCompress", 1, ScContext::zstdCompress),
+                JS_CFUNC_DEF("zstdDecompress", 1, ScContext::zstdDecompress),
             };
             RegisterBase(ctx, "Context", nullptr, funcs);
         }

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -11,14 +11,15 @@
 
 #ifdef ENABLE_SCRIPTING
 
+    #include "../../../../thirdparty/base64.hpp"
     #include "../../../Game.h"
     #include "../../../OpenRCT2.h"
     #include "../../../actions/GameActionRunner.h"
+    #include "../../../core/Compression.h"
+    #include "../../../core/MemoryStream.h"
     #include "../../../interface/Screenshot.h"
     #include "../../../localisation/Formatting.h"
     #include "../../../object/ObjectManager.h"
-    #include "../../../core/Compression.h"
-    #include "../../../core/MemoryStream.h"
     #include "../../../scenario/Scenario.h"
     #include "../../HookEngine.h"
     #include "../../IconNames.hpp"
@@ -30,7 +31,6 @@
 
     #include <cstdio>
     #include <memory>
-    #include "../../../../thirdparty/base64.hpp"
     #include <zstd.h>
 
 namespace OpenRCT2::Scripting
@@ -491,7 +491,9 @@ namespace OpenRCT2::Scripting
                 if (Compression::zstdCompress(source, size, dest, Compression::ZstdMetadata::both, level))
                 {
                     JSValue obj = JS_NewObject(ctx);
-                    JS_SetPropertyStr(ctx, obj, "data", JS_NewUint8ArrayCopy(ctx, static_cast<const uint8_t*>(dest.GetData()), dest.GetLength()));
+                    JS_SetPropertyStr(
+                        ctx, obj, "data",
+                        JS_NewUint8ArrayCopy(ctx, static_cast<const uint8_t*>(dest.GetData()), dest.GetLength()));
                     return obj;
                 }
                 else

--- a/test/tests/ScriptingTests.cpp
+++ b/test/tests/ScriptingTests.cpp
@@ -73,4 +73,63 @@ TEST_F(ScriptingTests, MultipleSubscribersToSameEventShouldNotCrash)
     hookEngine.Call(HookType::intervalTick, arg, false);
 }
 
+TEST_F(ScriptingTests, Base64AndZstdAPIs)
+{
+    auto& scriptEngine = static_cast<ScriptEngine&>(_context->GetScriptEngine());
+
+    const char* pluginCode = R"(
+        registerPlugin({
+            name: 'test-plugin-crypto',
+            version: '1.0.0',
+            authors: ['openrct2-test'],
+            type: 'remote',
+            licence: 'MIT',
+            main: function () {
+                // Base64 Test
+                const originalData = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+                const encoded = context.base64encode(originalData);
+                if (encoded.data !== "SGVsbG8=") {
+                    throw new Error("Base64 encode failed: " + encoded.data);
+                }
+                const decoded = context.base64decode(encoded.data);
+                if (decoded.data.length !== 5 || decoded.data[0] !== 72 || decoded.data[4] !== 111) {
+                    throw new Error("Base64 decode failed");
+                }
+
+                // Zstd Test
+                const largeData = new Uint8Array(100).fill(65); // 100 'A's
+                const compressed = context.zstdCompress(largeData);
+                if (compressed.error) {
+                    throw new Error("Zstd compress failed: " + compressed.message);
+                }
+                const decompressed = context.zstdDecompress(compressed.data);
+                if (decompressed.error) {
+                    throw new Error("Zstd decompress failed: " + decompressed.message);
+                }
+                if (decompressed.data.length !== 100 || decompressed.data[0] !== 65) {
+                    throw new Error("Zstd decompression data mismatch");
+                }
+
+                // Zstd Test with explicit length
+                const decompressed2 = context.zstdDecompress(compressed.data, 100);
+                if (decompressed2.data.length !== 100) {
+                    throw new Error("Zstd decompression with explicit length failed");
+                }
+
+                // Zstd Test with smaller length
+                const decompressed3 = context.zstdDecompress(compressed.data, 50);
+                if (decompressed3.data.length !== 50 || !decompressed3.moreAvailable) {
+                    throw new Error("Zstd decompression with smaller length failed");
+                }
+
+                console.log("Crypto tests passed!");
+            }
+        });
+    )";
+
+    scriptEngine.AddNetworkPlugin(pluginCode);
+    scriptEngine.LoadTransientPlugins();
+    scriptEngine.Tick();
+}
+
 #endif


### PR DESCRIPTION
Expose zstd and base64 APIs to plugins for binary data processing. Added zstdCompress, zstdDecompress, base64encode, and base64decode to the scripting context. Includes unit tests.

---
*PR created automatically by Jules for task [1578135428669885903](https://jules.google.com/task/1578135428669885903) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added base64 encoding and decoding functions to the scripting API.
  * Added zstandard (zstd) compression and decompression functions to the scripting API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->