### PR TITLE
Optimize viewport performance for multiple windows

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -959,37 +959,51 @@ namespace OpenRCT2
             columnRT.cullingY = -cullingY;
             columnRT.cullingWidth = columnWidth;
             columnRT.cullingHeight = cullingY * 2;
+        }
 
-            if (useMultithreading)
-            {
-                _paintJobs->AddTask([session]() -> void { ViewportFillColumn(*session); });
-            }
-            else
-            {
-                ViewportFillColumn(*session);
-            }
+        // If there are only a few columns, it is faster to paint them serially
+        // than to deal with the overhead of the job pool.
+        constexpr size_t kMultithreadingThreshold = 4;
+        if (_paintColumns.size() <= kMultithreadingThreshold)
+        {
+            useMultithreading = false;
+            useParallelDrawing = false;
         }
 
         if (useMultithreading)
         {
-            _paintJobs->Join();
-        }
-
-        // Paint columns.
-        for (auto* session : _paintColumns)
-        {
             if (useParallelDrawing)
             {
-                _paintJobs->AddTask([session]() -> void { ViewportPaintColumn(*session); });
+                for (auto* session : _paintColumns)
+                {
+                    _paintJobs->AddTask([session]() -> void {
+                        ViewportFillColumn(*session);
+                        ViewportPaintColumn(*session);
+                    });
+                }
+                _paintJobs->Join();
             }
             else
             {
-                ViewportPaintColumn(*session);
+                for (auto* session : _paintColumns)
+                {
+                    _paintJobs->AddTask([session]() -> void { ViewportFillColumn(*session); });
+                }
+                _paintJobs->Join();
+
+                for (auto* session : _paintColumns)
+                {
+                    ViewportPaintColumn(*session);
+                }
             }
         }
-        if (useParallelDrawing)
+        else
         {
-            _paintJobs->Join();
+            for (auto* session : _paintColumns)
+            {
+                ViewportFillColumn(*session);
+                ViewportPaintColumn(*session);
+            }
         }
 
         // Release resources.


### PR DESCRIPTION
Optimized ViewportPaint to reduce thread pool overhead for small viewports and halved the number of synchronization points when parallel drawing is enabled. This significantly improves performance when multiple windows with viewports (like the Handyman window) are open.

---
*PR created automatically by Jules for task [899426865242350564](https://jules.google.com/task/899426865242350564) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked viewport rendering pipeline for improved performance and efficiency across different rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->