### PR TITLE
Add CI job for Windows 7 support via VS2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,8 @@ jobs:
             palettes.dat
             fonts.dat
             tracks.dat
-  windows:
-    name: Windows
+  windows-vs2026:
+    name: Windows (VS2026)
     runs-on: windows-2025-vs2026
     needs: [check-code-formatting, build_variables, g2dat]
     strategy:
@@ -194,6 +194,7 @@ jobs:
     env:
       PLATFORM: ${{ matrix.platform }}
       DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}
+      OPENRCT2_VERSION: ${{ env.OPENRCT2_VERSION }}
     steps:
       - name: Setup environment
         run: |
@@ -205,9 +206,6 @@ jobs:
           fi
       - name: Checkout
         uses: actions/checkout@v6
-      - name: find cl.exe
-        run: |
-          find /c/Program\ Files/ -name cl.exe || true
       - name: Install MSVC problem matcher
         uses: ammaraskar/msvc-problem-matcher@master
       - name: Build OpenRCT2
@@ -289,7 +287,7 @@ jobs:
           output-artifact-directory: files-signed
           parameters: |
             version: "${{ env.OPENRCT2_VERSION }}${{ env.OPENRCT2_VERSION_EXTRA }}"
-            product: "OpenRCT2 ${{ matrix.platform }} Installer for Windows 7 and later"
+            product: "OpenRCT2 ${{ matrix.platform }} Installer for Windows 10 and later"
       - name: Upload signed installer artifact (CI)
         id: upload-windows-installer-signed
         if: ${{ needs.build_variables.outputs.sign == 'true' }}
@@ -317,6 +315,133 @@ jobs:
           . scripts/setenv
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
             upload-backtrace-symbols artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-windows-symbols-*.zip
+          else
+            echo 'Not going to push build'
+          fi
+  windows-vs2022:
+    name: Windows (VS2022)
+    runs-on: windows-2022
+    needs: [check-code-formatting, build_variables, g2dat]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [win32, x64]
+    env:
+      PLATFORM: ${{ matrix.platform }}
+      DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}
+      OPENRCT2_VERSION: ${{ env.OPENRCT2_VERSION }}
+    steps:
+      - name: Setup environment
+        run: |
+          BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)
+          if [[ $BRANCH == 'develop' || $GITHUB_REF_TYPE == 'tag' ]]; then
+             echo "CONFIGURATION=ReleaseLTCG" >> "$GITHUB_ENV"
+          else
+             echo "CONFIGURATION=Release" >> "$GITHUB_ENV"
+          fi
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install MSVC problem matcher
+        uses: ammaraskar/msvc-problem-matcher@master
+      - name: Build OpenRCT2
+        run: . scripts/setenv && build
+      - name: Upload unsigned binaries
+        id: upload-windows-binaries-unsigned
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-unsigned-${{ matrix.platform }}
+          path: |
+            bin/openrct2.exe
+            bin/openrct2.com
+      # Sign the binaries first, so that all other artifacts (portable, installer, symbols) use signed binaries
+      - name: Sign binaries
+        id: sign-binaries
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: 645b821f-6283-45e1-8198-264997072801
+          project-slug: OpenRCT2
+          signing-policy-slug: ${{ needs.build_variables.outputs.certificate }}
+          artifact-configuration-slug: 'binaries'
+          github-artifact-id: ${{ steps.upload-windows-binaries-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: files-signed
+          parameters: |
+            version: "${{ env.OPENRCT2_VERSION }}.${{ needs.build_variables.outputs.distance }}-${{ needs.build_variables.outputs.short-sha }}"
+      - name: Use signed binaries
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
+        run: |
+          mv files-signed/openrct2.com bin/openrct2.com
+          mv files-signed/openrct2.exe bin/openrct2.exe
+      - name: Build artifacts
+        run: |
+          . scripts/setenv -q
+          build-portable
+          build-symbols
+          build-installer -i
+          echo "OPENRCT2_VERSION_EXTRA=$OPENRCT2_VERSION_EXTRA" >> "$GITHUB_ENV"
+      - name: Rename artifacts
+        run: |
+          mv artifacts/openrct2-portable-*.zip artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-portable-$PLATFORM.zip
+          mv artifacts/openrct2-installer-*.exe artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-installer-$PLATFORM.exe
+          mv artifacts/openrct2-symbols-*.zip artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-symbols-$PLATFORM.zip
+      - name: Upload portable artifact (CI)
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-portable-${{ matrix.platform }}
+          path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-portable-${{ matrix.platform }}.zip
+          if-no-files-found: error
+      - name: Upload unsigned installer artifact (CI)
+        id: upload-windows-installer-unsigned
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-installer-${{ matrix.platform }}-unsigned
+          path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-installer-${{ matrix.platform }}.exe
+          if-no-files-found: error
+      - name: Sign installer
+        id: sign-installer
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: 645b821f-6283-45e1-8198-264997072801
+          project-slug: OpenRCT2
+          signing-policy-slug: ${{ needs.build_variables.outputs.certificate }}
+          artifact-configuration-slug: 'installer'
+          github-artifact-id: ${{ steps.upload-windows-installer-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: files-signed
+          parameters: |
+            version: "${{ env.OPENRCT2_VERSION }}${{ env.OPENRCT2_VERSION_EXTRA }}"
+            product: "OpenRCT2 ${{ matrix.platform }} Installer for Windows 7 and 8.x"
+      - name: Upload signed installer artifact (CI)
+        id: upload-windows-installer-signed
+        if: ${{ needs.build_variables.outputs.sign == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-installer-${{ matrix.platform }}
+          path: files-signed/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-installer-${{ matrix.platform }}.exe
+          if-no-files-found: error
+      - name: Upload symbols artifact (CI)
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-symbols-${{ matrix.platform }}
+          path: artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-symbols-${{ matrix.platform }}.zip
+          if-no-files-found: error
+      - name: Run Tests
+        run: . scripts/setenv -q && run-tests
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "artifacts/test-**.xml"
+      - name: Upload symbols (backtrace.io)
+        run: |
+          . scripts/setenv
+          if [[ "$OPENRCT2_PUSH" == "true" ]]; then
+            upload-backtrace-symbols artifacts/OpenRCT2-${{ needs.build_variables.outputs.name }}-win7-symbols-*.zip
           else
             echo 'Not going to push build'
           fi
@@ -735,7 +860,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-slim
-    needs: [build_variables, linux-portable, android, linux-appimage, macos-universal, windows]
+    needs: [build_variables, linux-portable, android, linux-appimage, macos-universal, windows-vs2026, windows-vs2022]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
I have implemented a new CI job for Windows using VS2022 to maintain support for Windows 7 and 8.x. 

Key changes:
1. **Renamed existing Windows job**: The previous `windows` job is now `windows-vs2026`. Its installer product description now specifies "Windows 10 and later".
2. **Added `windows-vs2022` job**: This new job uses the `windows-2022` runner and targets `win32` and `x64`. 
3. **Distinct Artifact Naming**: Artifacts from the VS2022 job now include `win7` in their names (e.g., `OpenRCT2-...-win7-portable-x64.zip`) to prevent clashes and clearly identify the legacy-compatible builds.
4. **Updated Signing**: The VS2022 installer's product description is set to "OpenRCT2 [Platform] Installer for Windows 7 and 8.x".
5. **Release Integration**: The `release` job now depends on both `windows-vs2026` and `windows-vs2022`, ensuring all Windows variants are included in the final release.
6. **Environment and Shell**: Ensured `OPENRCT2_VERSION` is available in the new job and that the global `shell: bash` default is respected.


---
*PR created automatically by Jules for task [15116361683439667271](https://jules.google.com/task/15116361683439667271) started by @janisozaur*