### PR TITLE
Fix server crash caused by unauthenticated map requests

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1869,6 +1869,13 @@ namespace OpenRCT2::Network
                     LOG_VERBOSE("Exception during packet processing: %s", ex.what());
                 }
             }
+            else
+            {
+                LOG_WARNING(
+                    "Connection %s sent command %u that requires authentication, disconnecting.",
+                    connection.Socket->GetIpAddress().c_str(), static_cast<uint32_t>(packet.GetCommand()));
+                connection.Disconnect();
+            }
         }
 
         packet.Clear();
@@ -2640,6 +2647,13 @@ namespace OpenRCT2::Network
             {
                 connection.RequestedObjects.push_back(item);
             }
+        }
+
+        if (connection.player == nullptr)
+        {
+            LOG_WARNING("Connection %s requested map but has no player, disconnecting.", connection.Socket->GetIpAddress().c_str());
+            connection.Disconnect();
+            return;
         }
 
         auto player_name = connection.player->Name.c_str();

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2651,7 +2651,8 @@ namespace OpenRCT2::Network
 
         if (connection.player == nullptr)
         {
-            LOG_WARNING("Connection %s requested map but has no player, disconnecting.", connection.Socket->GetIpAddress().c_str());
+            LOG_WARNING(
+                "Connection %s requested map but has no player, disconnecting.", connection.Socket->GetIpAddress().c_str());
             connection.Disconnect();
             return;
         }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1869,7 +1869,7 @@ namespace OpenRCT2::Network
                     LOG_VERBOSE("Exception during packet processing: %s", ex.what());
                 }
             }
-            else
+            else if (GetMode() == Mode::server)
             {
                 LOG_WARNING(
                     "Connection %s sent command %u that requires authentication, disconnecting.",
@@ -2426,6 +2426,9 @@ namespace OpenRCT2::Network
     {
         auto player = AddPlayer(std::string(name), keyhash);
         connection.player = player;
+
+        ServerSendAuth(connection);
+
         if (player != nullptr)
         {
             char text[256];
@@ -2781,6 +2784,7 @@ namespace OpenRCT2::Network
                 {
                     connection.AuthStatus = Auth::ok;
                     ServerClientJoined(name, hash, connection);
+                    return;
                 }
                 else
                 {

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -55,7 +55,6 @@ namespace OpenRCT2::Network
             case Command::objectsList:
             case Command::scriptsHeader:
             case Command::scriptsData:
-            case Command::mapRequest:
             case Command::heartbeat:
                 return false;
             default:

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/LanguagePackTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/LocalisationTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/MultiLaunch.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/NetworkTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"

--- a/test/tests/NetworkTests.cpp
+++ b/test/tests/NetworkTests.cpp
@@ -1,0 +1,40 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/network/NetworkPacket.h>
+
+using namespace OpenRCT2::Network;
+
+TEST(NetworkTests, MapRequestRequiresAuth)
+{
+    Packet packet(Command::mapRequest);
+    EXPECT_TRUE(packet.CommandRequiresAuth());
+}
+
+TEST(NetworkTests, OtherCommandsRequireAuth)
+{
+    Packet chatPacket(Command::chat);
+    EXPECT_TRUE(chatPacket.CommandRequiresAuth());
+
+    Packet gameActionPacket(Command::gameAction);
+    EXPECT_TRUE(gameActionPacket.CommandRequiresAuth());
+}
+
+TEST(NetworkTests, SomeCommandsDoNotRequireAuth)
+{
+    Packet pingPacket(Command::ping);
+    EXPECT_FALSE(pingPacket.CommandRequiresAuth());
+
+    Packet authPacket(Command::auth);
+    EXPECT_FALSE(authPacket.CommandRequiresAuth());
+
+    Packet gameInfoPacket(Command::gameInfo);
+    EXPECT_FALSE(gameInfoPacket.CommandRequiresAuth());
+}

--- a/test/tests/NetworkTests.cpp
+++ b/test/tests/NetworkTests.cpp
@@ -22,7 +22,7 @@ class MockTcpSocket final : public ITcpSocket
 public:
     SocketStatus GetStatus() const override
     {
-        return SocketStatus::connected;
+        return _status;
     }
     const char* GetError() const override
     {
@@ -39,9 +39,11 @@ public:
 
     void Listen(uint16_t) override
     {
+        _status = SocketStatus::listening;
     }
     void Listen(const std::string&, uint16_t) override
     {
+        _status = SocketStatus::listening;
     }
     std::unique_ptr<ITcpSocket> Accept() override
     {
@@ -50,18 +52,36 @@ public:
 
     void Connect(const std::string&, uint16_t) override
     {
+        _status = SocketStatus::connected;
     }
     void ConnectAsync(const std::string&, uint16_t) override
     {
+        _status = SocketStatus::connecting;
+    }
+
+    void SetInboundData(const std::vector<uint8_t>& data)
+    {
+        _inboundData = data;
+        _inboundOffset = 0;
     }
 
     size_t SendData(const void*, size_t size) override
     {
         return size;
     }
-    ReadPacket ReceiveData(void*, size_t, size_t*) override
+    ReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) override
     {
-        return ReadPacket::noData;
+        if (_inboundOffset >= _inboundData.size())
+        {
+            *sizeReceived = 0;
+            return ReadPacket::noData;
+        }
+        size_t available = _inboundData.size() - _inboundOffset;
+        size_t toCopy = std::min(size, available);
+        std::memcpy(buffer, _inboundData.data() + _inboundOffset, toCopy);
+        _inboundOffset += toCopy;
+        *sizeReceived = toCopy;
+        return ReadPacket::success;
     }
 
     void SetNoDelay(bool) override
@@ -73,20 +93,17 @@ public:
     }
     void Disconnect() override
     {
-        _disconnected = true;
+        _status = SocketStatus::closed;
     }
     void Close() override
     {
-        _disconnected = true;
-    }
-
-    bool IsDisconnected() const
-    {
-        return _disconnected;
+        _status = SocketStatus::closed;
     }
 
 private:
-    bool _disconnected = false;
+    SocketStatus _status = SocketStatus::connected;
+    std::vector<uint8_t> _inboundData;
+    size_t _inboundOffset = 0;
 };
 
 class NetworkTests : public testing::Test
@@ -115,7 +132,6 @@ TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
 
     Connection connection;
     auto mockSocket = std::make_unique<MockTcpSocket>();
-    auto* mockSocketPtr = mockSocket.get();
     connection.Socket = std::move(mockSocket);
     connection.AuthStatus = Auth::none;
     connection.player = nullptr;
@@ -127,7 +143,7 @@ TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
     // After the fix, it should detect connection.player == nullptr and disconnect.
     network.ServerHandleMapRequest(connection, packet);
 
-    EXPECT_TRUE(mockSocketPtr->IsDisconnected() || connection.ShouldDisconnect);
+    EXPECT_TRUE(connection.ShouldDisconnect);
 }
 
 TEST_F(NetworkTests, ProcessPacketInterceptsUnauthorizedCommands)
@@ -135,9 +151,7 @@ TEST_F(NetworkTests, ProcessPacketInterceptsUnauthorizedCommands)
     NetworkBase network(*_context);
 
     Connection connection;
-    auto mockSocket = std::make_unique<MockTcpSocket>();
-    auto* mockSocketPtr = mockSocket.get();
-    connection.Socket = std::move(mockSocket);
+    connection.Socket = std::make_unique<MockTcpSocket>();
     connection.AuthStatus = Auth::none;
 
     // Chat command requires authentication
@@ -147,7 +161,46 @@ TEST_F(NetworkTests, ProcessPacketInterceptsUnauthorizedCommands)
     // ProcessPacket should check CommandRequiresAuth and disconnect because AuthStatus != Auth::ok
     network.ProcessPacket(connection, packet);
 
-    EXPECT_TRUE(mockSocketPtr->IsDisconnected() || connection.ShouldDisconnect);
+    EXPECT_TRUE(connection.ShouldDisconnect);
+}
+
+TEST_F(NetworkTests, IntegratedUnauthenticatedMapRequestDisconnects)
+{
+    // This test simulates receiving a mapRequest packet from the network
+    // while unauthenticated, and verifies that the server disconnects the client.
+    NetworkBase network(*_context);
+
+    // Set network to server mode
+    network.BeginServer(0, "127.0.0.1");
+
+    Connection connection;
+    auto mockSocket = std::make_unique<MockTcpSocket>();
+
+    // Manually construct a mapRequest packet in ORT2 format.
+    // Magic 'ORT2' is 0x3254524F in host order (Little Endian).
+    // On the wire it is expected to be Network Order (Big Endian).
+    // So 0x3254524F -> HostToNetwork -> 0x4F525432.
+    // Bytes of 0x4F525432 on a Little Endian machine are 32 54 52 4F.
+    std::vector<uint8_t> bytes = {
+        0x32, 0x54, 0x52, 0x4F, // Magic (corresponds to 0x4F525432 in memory on LE, which swaps to 0x3254524F)
+        0x00, 0x02,             // Version 2 (Big Endian)
+        0x00, 0x00, 0x00, 0x04, // Size 4 (Big Endian)
+        0x00, 0x00, 0x00, 0x0F, // Id 15 (mapRequest, Big Endian)
+        0x00, 0x00, 0x00, 0x00  // Data: 0 objects
+    };
+
+    mockSocket->SetInboundData(bytes);
+    connection.Socket = std::move(mockSocket);
+    connection.AuthStatus = Auth::none;
+
+    // 1. Receive data and fill inbound buffer
+    connection.update();
+
+    // 2. Process connection (reads packet and processes it)
+    network.ProcessConnection(connection);
+
+    // Should be disconnected because mapRequest requires authentication now.
+    EXPECT_TRUE(connection.ShouldDisconnect);
 }
 
 TEST_F(NetworkTests, MapRequestRequiresAuth)

--- a/test/tests/NetworkTests.cpp
+++ b/test/tests/NetworkTests.cpp
@@ -8,33 +8,150 @@
  *****************************************************************************/
 
 #include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/network/NetworkBase.h>
+#include <openrct2/network/NetworkConnection.h>
 #include <openrct2/network/NetworkPacket.h>
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Network;
 
-TEST(NetworkTests, MapRequestRequiresAuth)
+class MockTcpSocket final : public ITcpSocket
+{
+public:
+    SocketStatus GetStatus() const override
+    {
+        return SocketStatus::connected;
+    }
+    const char* GetError() const override
+    {
+        return nullptr;
+    }
+    const char* GetHostName() const override
+    {
+        return "127.0.0.1";
+    }
+    std::string GetIpAddress() const override
+    {
+        return "127.0.0.1";
+    }
+
+    void Listen(uint16_t) override
+    {
+    }
+    void Listen(const std::string&, uint16_t) override
+    {
+    }
+    std::unique_ptr<ITcpSocket> Accept() override
+    {
+        return nullptr;
+    }
+
+    void Connect(const std::string&, uint16_t) override
+    {
+    }
+    void ConnectAsync(const std::string&, uint16_t) override
+    {
+    }
+
+    size_t SendData(const void*, size_t size) override
+    {
+        return size;
+    }
+    ReadPacket ReceiveData(void*, size_t, size_t*) override
+    {
+        return ReadPacket::noData;
+    }
+
+    void SetNoDelay(bool) override
+    {
+    }
+
+    void Finish() override
+    {
+    }
+    void Disconnect() override
+    {
+        _disconnected = true;
+    }
+    void Close() override
+    {
+        _disconnected = true;
+    }
+
+    bool IsDisconnected() const
+    {
+        return _disconnected;
+    }
+
+private:
+    bool _disconnected = false;
+};
+
+class NetworkTests : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        gOpenRCT2Headless = true;
+        gOpenRCT2NoGraphics = true;
+        _context = CreateContext();
+        try
+        {
+            _context->Initialise();
+        }
+        catch (...)
+        {
+        }
+    }
+
+    std::unique_ptr<IContext> _context;
+};
+
+TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
+{
+    NetworkBase network(*_context);
+
+    Connection connection;
+    auto mockSocket = std::make_unique<MockTcpSocket>();
+    auto* mockSocketPtr = mockSocket.get();
+    connection.Socket = std::move(mockSocket);
+    connection.AuthStatus = Auth::none;
+    connection.player = nullptr;
+
+    Packet packet(Command::mapRequest);
+    packet << static_cast<uint32_t>(0); // 0 objects
+
+    // Before the fix, this would crash because it accesses connection.player->Name
+    // After the fix, it should detect connection.player == nullptr and disconnect.
+    network.ServerHandleMapRequest(connection, packet);
+
+    EXPECT_TRUE(mockSocketPtr->IsDisconnected() || connection.ShouldDisconnect);
+}
+
+TEST_F(NetworkTests, ProcessPacketInterceptsUnauthorizedCommands)
+{
+    NetworkBase network(*_context);
+
+    Connection connection;
+    auto mockSocket = std::make_unique<MockTcpSocket>();
+    auto* mockSocketPtr = mockSocket.get();
+    connection.Socket = std::move(mockSocket);
+    connection.AuthStatus = Auth::none;
+
+    // Chat command requires authentication
+    Packet packet(Command::chat);
+    packet.WriteString("Hello");
+
+    // ProcessPacket should check CommandRequiresAuth and disconnect because AuthStatus != Auth::ok
+    network.ProcessPacket(connection, packet);
+
+    EXPECT_TRUE(mockSocketPtr->IsDisconnected() || connection.ShouldDisconnect);
+}
+
+TEST_F(NetworkTests, MapRequestRequiresAuth)
 {
     Packet packet(Command::mapRequest);
     EXPECT_TRUE(packet.CommandRequiresAuth());
-}
-
-TEST(NetworkTests, OtherCommandsRequireAuth)
-{
-    Packet chatPacket(Command::chat);
-    EXPECT_TRUE(chatPacket.CommandRequiresAuth());
-
-    Packet gameActionPacket(Command::gameAction);
-    EXPECT_TRUE(gameActionPacket.CommandRequiresAuth());
-}
-
-TEST(NetworkTests, SomeCommandsDoNotRequireAuth)
-{
-    Packet pingPacket(Command::ping);
-    EXPECT_FALSE(pingPacket.CommandRequiresAuth());
-
-    Packet authPacket(Command::auth);
-    EXPECT_FALSE(authPacket.CommandRequiresAuth());
-
-    Packet gameInfoPacket(Command::gameInfo);
-    EXPECT_FALSE(gameInfoPacket.CommandRequiresAuth());
 }

--- a/test/tests/NetworkTests.cpp
+++ b/test/tests/NetworkTests.cpp
@@ -149,6 +149,8 @@ TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
 TEST_F(NetworkTests, ProcessPacketInterceptsUnauthorizedCommands)
 {
     NetworkBase network(*_context);
+    // Set to server mode
+    network.BeginServer(0, "127.0.0.1");
 
     Connection connection;
     connection.Socket = std::make_unique<MockTcpSocket>();

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -95,8 +95,8 @@
     <ClCompile Include="IniWriterTest.cpp" />
     <ClCompile Include="LocalisationTest.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
-    <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="NetworkTests.cpp" />
+    <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
     <ClCompile Include="RideRatings.cpp" />

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="LocalisationTest.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
+    <ClCompile Include="NetworkTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
     <ClCompile Include="RideRatings.cpp" />


### PR DESCRIPTION
This PR fixes a server crash vulnerability where unauthenticated clients could send a `mapRequest` packet, causing a null pointer dereference in `NetworkBase::ServerHandleMapRequest` when attempting to access `connection.player->Name`.

Key changes:
1.  **Enforced Authentication for Map Requests**: Updated `Packet::CommandRequiresAuth` in `NetworkPacket.cpp` to include `Command::mapRequest`.
2.  **Server Protection**: Modified `NetworkBase::ProcessPacket` to explicitly disconnect any client that sends a command requiring authentication without being successfully authenticated.
3.  **Defense in Depth**: Added a null check for `connection.player` in `ServerHandleMapRequest`. If a connection without an associated player reaches this point, the server now logs a warning and disconnects the client instead of crashing.
4.  **Testing**: 
    - Created `test/tests/NetworkTests.cpp` with unit tests verifying that `mapRequest` correctly requires authentication.
    - Updated `test/tests/CMakeLists.txt` and `test/tests/tests.vcxproj` to include the new tests.

These changes prevent the reported crash and improve the overall robustness of the network protocol enforcement.

---
*PR created automatically by Jules for task [3381157083331647100](https://jules.google.com/task/3381157083331647100) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map requests now require client authentication; server sends auth status to newly joined clients.

* **Bug Fixes**
  * Server verifies a valid player connection before sending map data and disconnects/logs when missing.
  * Unauthorized network commands are intercepted, logged, and the client is disconnected to improve stability and security.

* **Tests**
  * Added network tests validating authentication enforcement and safe handling of unauthenticated map requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janisozaur/OpenRCT2/pull/99)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->