### PR TITLE
Implement AVX-512 optimizations for drawing engine

### DIFF
--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -63,7 +63,7 @@
              C4555: expression has no effect; expected expression with side-effect
       -->
       <PreprocessorDefinitions>OPENGL_NO_LINK;_CRT_SECURE_NO_WARNINGS;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">__AVX2__;__SSE4_1__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">__AVX512F__;__AVX512BW__;__AVX512DQ__;__AVX512VL__;__AVX512VBMI__;__AVX2__;__SSE4_1__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>ENABLE_SCRIPTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'!='true'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(UseSharedLibs)'=='true'">MultiThreadedDLL</RuntimeLibrary>

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -239,6 +239,7 @@ file(GLOB_RECURSE OPENRCT2_GUI_SOURCES
 if(X86 OR X86_64)
     set_source_files_properties(${ORCT2_ROOT}/src/openrct2/drawing/SSE41Drawing.cpp PROPERTIES COMPILE_FLAGS -msse4.1)
     set_source_files_properties(${ORCT2_ROOT}/src/openrct2/drawing/AVX2Drawing.cpp PROPERTIES COMPILE_FLAGS -mavx2)
+    set_source_files_properties(${ORCT2_ROOT}/src/openrct2/drawing/AVX512Drawing.cpp PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl -mavx512vbmi")
 endif()
 
 file(GLOB_RECURSE OPENRCT2_CLI_SOURCES

--- a/src/openrct2/CMakeLists.txt
+++ b/src/openrct2/CMakeLists.txt
@@ -275,6 +275,7 @@ endif()
 if((X86 OR X86_64) AND NOT MSVC AND NOT EMSCRIPTEN)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/SSE41Drawing.cpp PROPERTIES COMPILE_FLAGS -msse4.1)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/AVX2Drawing.cpp PROPERTIES COMPILE_FLAGS -mavx2)
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/drawing/AVX512Drawing.cpp PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512dq -mavx512vl -mavx512vbmi")
 endif()
 
 # Add headers check to verify all headers carry their dependencies.

--- a/src/openrct2/drawing/AVX512Drawing.cpp
+++ b/src/openrct2/drawing/AVX512Drawing.cpp
@@ -13,8 +13,7 @@
 
 using OpenRCT2::Drawing::PaletteIndex;
 
-#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512DQ__) && defined(__AVX512VL__)               \
-    && defined(__AVX512VBMI__)
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512DQ__) && defined(__AVX512VL__) && defined(__AVX512VBMI__)
 
     #include <immintrin.h>
 
@@ -43,7 +42,7 @@ void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t 
             __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
 
             // Select between res12 and res34 based on the 7th bit of indices
-            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(0x80u));
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<uint8_t>(0x80U)));
             __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
 
             _mm512_storeu_si512(reinterpret_cast<__m512i*>(d), res);
@@ -52,13 +51,13 @@ void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t 
 
         if (ww > 0)
         {
-            const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1);
+            const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1ULL);
             __m512i indices = _mm512_maskz_loadu_epi8(tailMask, d);
 
             __m512i res12 = _mm512_permutex2var_epi8(map, indices, map2);
             __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
 
-            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(0x80u));
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<uint8_t>(0x80U)));
             __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
 
             _mm512_mask_storeu_epi8(d, tailMask, res);
@@ -67,8 +66,8 @@ void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t 
 }
 
 void LightFxRenderToTextureAvx512(
-    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height,
-    const uint32_t* palette, const uint32_t* lightPalette, const uint8_t* lightBits)
+    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height, const uint32_t* palette,
+    const uint32_t* lightPalette, const uint8_t* lightBits)
 {
     const __m512i v6 = _mm512_set1_epi32(6);
     const __m512i v255 = _mm512_set1_epi32(255);
@@ -82,10 +81,10 @@ void LightFxRenderToTextureAvx512(
         const uint8_t* lb = lightBits + yy * width;
 
         int32_t ww = width;
-        for (; ww > 0; )
+        for (; ww > 0;)
         {
             int32_t count = std::min(ww, 16);
-            __mmask16 loadMask = (1U << count) - 1;
+            __mmask16 loadMask = static_cast<__mmask16>((1U << count) - 1U);
 
             __m128i indices8 = _mm_maskz_loadu_epi8(loadMask, b);
             __m512i indices32 = _mm512_cvtepu8_epi32(indices8);
@@ -165,7 +164,7 @@ void MaskAvx512(
 
             if (ww > 0)
             {
-                const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1);
+                const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1ULL);
                 const __m512i colour = _mm512_maskz_loadu_epi8(tailMask, c);
                 const __m512i mask = _mm512_maskz_loadu_epi8(tailMask, m);
                 const __m512i dest = _mm512_maskz_loadu_epi8(tailMask, d);
@@ -211,15 +210,14 @@ void MaskAvx512(
         #error You have to compile this file with AVX-512 enabled, when targeting x86!
     #endif
 
-void FilterRectAvx512(
-    PaletteIndex* RESTRICT dst, int32_t width, int32_t height, int32_t stride, const PaletteIndex* paletteMap)
+void FilterRectAvx512(PaletteIndex* RESTRICT dst, int32_t width, int32_t height, int32_t stride, const PaletteIndex* paletteMap)
 {
     OpenRCT2::Guard::Fail("AVX-512 FilterRect function called on a CPU that doesn't support AVX-512");
 }
 
 void LightFxRenderToTextureAvx512(
-    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height,
-    const uint32_t* palette, const uint32_t* lightPalette, const uint8_t* lightBits)
+    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height, const uint32_t* palette,
+    const uint32_t* lightPalette, const uint8_t* lightBits)
 {
     OpenRCT2::Guard::Fail("AVX-512 LightFX function called on a CPU that doesn't support AVX-512");
 }

--- a/src/openrct2/drawing/AVX512Drawing.cpp
+++ b/src/openrct2/drawing/AVX512Drawing.cpp
@@ -8,8 +8,11 @@
  *****************************************************************************/
 
 #include "../core/Guard.hpp"
+#include "Drawing.Sprite.h"
 #include "Drawing.h"
 #include "PaletteIndex.h"
+
+#include <algorithm>
 
 using OpenRCT2::Drawing::PaletteIndex;
 
@@ -42,7 +45,7 @@ void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t 
             __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
 
             // Select between res12 and res34 based on the 7th bit of indices
-            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<uint8_t>(0x80U)));
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<int8_t>(0x80)));
             __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
 
             _mm512_storeu_si512(reinterpret_cast<__m512i*>(d), res);
@@ -57,7 +60,7 @@ void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t 
             __m512i res12 = _mm512_permutex2var_epi8(map, indices, map2);
             __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
 
-            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<uint8_t>(0x80U)));
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(static_cast<int8_t>(0x80)));
             __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
 
             _mm512_mask_storeu_epi8(d, tailMask, res);
@@ -81,10 +84,10 @@ void LightFxRenderToTextureAvx512(
         const uint8_t* lb = lightBits + yy * width;
 
         int32_t ww = width;
-        for (; ww > 0;)
+        while (ww > 0)
         {
             int32_t count = std::min(ww, 16);
-            __mmask16 loadMask = static_cast<__mmask16>((1U << count) - 1U);
+            __mmask16 loadMask = static_cast<__mmask16>((1ULL << count) - 1ULL);
 
             __m128i indices8 = _mm_maskz_loadu_epi8(loadMask, b);
             __m512i indices32 = _mm512_cvtepu8_epi32(indices8);

--- a/src/openrct2/drawing/AVX512Drawing.cpp
+++ b/src/openrct2/drawing/AVX512Drawing.cpp
@@ -1,0 +1,234 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../core/Guard.hpp"
+#include "Drawing.h"
+#include "PaletteIndex.h"
+
+using OpenRCT2::Drawing::PaletteIndex;
+
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512DQ__) && defined(__AVX512VL__)               \
+    && defined(__AVX512VBMI__)
+
+    #include <immintrin.h>
+
+void FilterRectAvx512(PaletteIndex* dst, int32_t width, int32_t height, int32_t stride, const PaletteIndex* paletteMap)
+{
+    const __m512i map = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(paletteMap));
+    const __m512i map2 = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(paletteMap + 64));
+    const __m512i map3 = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(paletteMap + 128));
+    const __m512i map4 = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(paletteMap + 192));
+
+    for (int32_t yy = 0; yy < height; yy++)
+    {
+        PaletteIndex* d = dst + yy * stride;
+        int32_t ww = width;
+        for (; ww >= 64; ww -= 64)
+        {
+            __m512i indices = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(d));
+
+            // VBMI _mm512_permutex2var_epi8 takes two tables and indices.
+            // Our palette map is 256 bytes, so we need two calls to cover all 256 indices.
+            // But wait, permute2var handles 128 indices (2*64).
+            // For 256 we need more.
+            // map1: 0-63, map2: 64-127, map3: 128-191, map4: 192-255
+
+            __m512i res12 = _mm512_permutex2var_epi8(map, indices, map2);
+            __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
+
+            // Select between res12 and res34 based on the 7th bit of indices
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(0x80u));
+            __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
+
+            _mm512_storeu_si512(reinterpret_cast<__m512i*>(d), res);
+            d += 64;
+        }
+
+        if (ww > 0)
+        {
+            const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1);
+            __m512i indices = _mm512_maskz_loadu_epi8(tailMask, d);
+
+            __m512i res12 = _mm512_permutex2var_epi8(map, indices, map2);
+            __m512i res34 = _mm512_permutex2var_epi8(map3, indices, map4);
+
+            __mmask64 highBitMask = _mm512_test_epi8_mask(indices, _mm512_set1_epi8(0x80u));
+            __m512i res = _mm512_mask_blend_epi8(highBitMask, res12, res34);
+
+            _mm512_mask_storeu_epi8(d, tailMask, res);
+        }
+    }
+}
+
+void LightFxRenderToTextureAvx512(
+    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height,
+    const uint32_t* palette, const uint32_t* lightPalette, const uint8_t* lightBits)
+{
+    const __m512i v6 = _mm512_set1_epi32(6);
+    const __m512i v255 = _mm512_set1_epi32(255);
+    const __m512i maskFF = _mm512_set1_epi32(0xFF);
+    const __m512i zero = _mm512_setzero_si512();
+
+    for (uint32_t yy = 0; yy < height; yy++)
+    {
+        uint32_t* dst = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(dstPixels) + yy * dstPitch);
+        const PaletteIndex* b = bits + yy * width;
+        const uint8_t* lb = lightBits + yy * width;
+
+        int32_t ww = width;
+        for (; ww > 0; )
+        {
+            int32_t count = std::min(ww, 16);
+            __mmask16 loadMask = (1U << count) - 1;
+
+            __m128i indices8 = _mm_maskz_loadu_epi8(loadMask, b);
+            __m512i indices32 = _mm512_cvtepu8_epi32(indices8);
+
+            __m512i darkColours = _mm512_mask_i32gather_epi32(zero, loadMask, indices32, palette, 4);
+            __m512i lightColours = _mm512_mask_i32gather_epi32(zero, loadMask, indices32, lightPalette, 4);
+
+            __m128i intensity8 = _mm_maskz_loadu_epi8(loadMask, lb);
+            __m512i intensity32 = _mm512_cvtepu8_epi32(intensity8);
+
+            __mmask16 notZero = _mm512_mask_cmpneq_epi32_mask(loadMask, intensity32, zero);
+
+            if (notZero == 0)
+            {
+                _mm512_mask_storeu_epi32(dst, loadMask, darkColours);
+            }
+            else
+            {
+                __m512i intensityMul = _mm512_mullo_epi32(intensity32, v6);
+
+                auto mixChannel = [&](int shift) {
+                    __m512i a = _mm512_and_si512(_mm512_srli_epi32(darkColours, shift), maskFF);
+                    __m512i bc = _mm512_and_si512(_mm512_srli_epi32(lightColours, shift), maskFF);
+                    __m512i bMul = _mm512_srli_epi32(_mm512_mullo_epi32(bc, intensityMul), 8);
+                    return _mm512_min_epu32(_mm512_add_epi32(a, bMul), v255);
+                };
+
+                __m512i r0 = mixChannel(0);
+                __m512i r1 = mixChannel(8);
+                __m512i r2 = mixChannel(16);
+                __m512i r3 = mixChannel(24);
+
+                __m512i res = _mm512_or_si512(
+                    _mm512_or_si512(r0, _mm512_slli_epi32(r1, 8)),
+                    _mm512_or_si512(_mm512_slli_epi32(r2, 16), _mm512_slli_epi32(r3, 24)));
+
+                _mm512_mask_storeu_epi32(dst, loadMask, res);
+            }
+
+            b += count;
+            lb += count;
+            dst += count;
+            ww -= count;
+        }
+    }
+}
+
+void MaskAvx512(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc,
+    PaletteIndex* RESTRICT dst, int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    if (width >= 64)
+    {
+        const __m512i zero = _mm512_setzero_si512();
+        for (int32_t yy = 0; yy < height; yy++)
+        {
+            uint8_t const* m = maskSrc + yy * (maskWrap + width);
+            uint8_t const* c = colourSrc + yy * (colourWrap + width);
+            PaletteIndex* d = dst + yy * (dstWrap + width);
+
+            int32_t ww = width;
+            for (; ww >= 64; ww -= 64)
+            {
+                const __m512i colour = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(c));
+                const __m512i mask = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(m));
+                const __m512i dest = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(d));
+
+                const __m512i mc = _mm512_and_si512(colour, mask);
+                const __mmask64 notZeroMask = _mm512_cmpneq_epi8_mask(mc, zero);
+                const __m512i blended = _mm512_mask_blend_epi8(notZeroMask, dest, mc);
+
+                _mm512_storeu_si512(reinterpret_cast<__m512i*>(d), blended);
+                m += 64;
+                c += 64;
+                d += 64;
+            }
+
+            if (ww > 0)
+            {
+                const __mmask64 tailMask = _cvtu64_mask64((1ULL << ww) - 1);
+                const __m512i colour = _mm512_maskz_loadu_epi8(tailMask, c);
+                const __m512i mask = _mm512_maskz_loadu_epi8(tailMask, m);
+                const __m512i dest = _mm512_maskz_loadu_epi8(tailMask, d);
+
+                const __m512i mc = _mm512_and_si512(colour, mask);
+                const __mmask64 notZeroMask = _mm512_cmpneq_epi8_mask(mc, zero);
+                const __m512i blended = _mm512_mask_blend_epi8(notZeroMask, dest, mc);
+
+                _mm512_mask_storeu_epi8(d, tailMask, blended);
+            }
+        }
+    }
+    else if (width == 32)
+    {
+        const int32_t maskWrapSIMD = maskWrap + 32;
+        const int32_t colourWrapSIMD = colourWrap + 32;
+        const int32_t dstWrapSIMD = dstWrap + 32;
+        const __m256i zero = _mm256_setzero_si256();
+        for (int32_t yy = 0; yy < height; yy++)
+        {
+            const __m256i colour = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(colourSrc + yy * colourWrapSIMD));
+            const __m256i mask = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(maskSrc + yy * maskWrapSIMD));
+            const __m256i dest = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(dst + yy * dstWrapSIMD));
+
+            const __m256i mc = _mm256_and_si256(colour, mask);
+
+            const __mmask32 notZeroMask = _mm256_cmpneq_epi8_mask(mc, zero);
+
+            const __m256i blended = _mm256_mask_blend_epi8(notZeroMask, dest, mc);
+
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + yy * dstWrapSIMD), blended);
+        }
+    }
+    else
+    {
+        MaskScalar(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
+    }
+}
+
+#else
+
+    #ifdef OPENRCT2_X86
+        #error You have to compile this file with AVX-512 enabled, when targeting x86!
+    #endif
+
+void FilterRectAvx512(
+    PaletteIndex* RESTRICT dst, int32_t width, int32_t height, int32_t stride, const PaletteIndex* paletteMap)
+{
+    OpenRCT2::Guard::Fail("AVX-512 FilterRect function called on a CPU that doesn't support AVX-512");
+}
+
+void LightFxRenderToTextureAvx512(
+    void* dstPixels, uint32_t dstPitch, const PaletteIndex* bits, uint32_t width, uint32_t height,
+    const uint32_t* palette, const uint32_t* lightPalette, const uint8_t* lightBits)
+{
+    OpenRCT2::Guard::Fail("AVX-512 LightFX function called on a CPU that doesn't support AVX-512");
+}
+
+void MaskAvx512(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc,
+    PaletteIndex* RESTRICT dst, int32_t maskWrap, int32_t colourWrap, int32_t dstWrap)
+{
+    OpenRCT2::Guard::Fail("AVX-512 Mask function called on a CPU that doesn't support AVX-512");
+}
+
+#endif

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -477,7 +477,12 @@ ImageCatalogue ImageId::GetCatalogue() const
 
 static auto GetMaskFunction()
 {
-    if (Platform::AVX2Available())
+    if (Platform::AVX512Available())
+    {
+        LOG_VERBOSE("registering AVX-512 mask function");
+        return MaskAvx512;
+    }
+    else if (Platform::AVX2Available())
     {
         LOG_VERBOSE("registering AVX2 mask function");
         return MaskAvx2;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -108,6 +108,15 @@ void MaskSse4_1(
 void MaskAvx2(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc,
     OpenRCT2::Drawing::PaletteIndex* RESTRICT dst, int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+void MaskAvx512(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc,
+    OpenRCT2::Drawing::PaletteIndex* RESTRICT dst, int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
+void FilterRectAvx512(
+    OpenRCT2::Drawing::PaletteIndex* dst, int32_t width, int32_t height, int32_t stride,
+    const OpenRCT2::Drawing::PaletteIndex* paletteMap);
+void LightFxRenderToTextureAvx512(
+    void* dstPixels, uint32_t dstPitch, const OpenRCT2::Drawing::PaletteIndex* bits, uint32_t width, uint32_t height,
+    const uint32_t* palette, const uint32_t* lightPalette, const uint8_t* lightBits);
 
 void MaskFn(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc,

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -18,6 +18,7 @@
 #include "../interface/Window.h"
 #include "../interface/WindowBase.h"
 #include "../paint/Paint.h"
+#include "../platform/Platform.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../ride/Vehicle.h"

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -1039,30 +1039,37 @@ namespace OpenRCT2::Drawing::LightFx
             return;
         }
 
-        for (uint32_t y = 0; y < height; y++)
+        if (Platform::AVX512Available())
         {
-            uintptr_t dstOffset = static_cast<uintptr_t>(y * dstPitch);
-            uint32_t* dst = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(dstPixels) + dstOffset);
-            for (uint32_t x = 0; x < width; x++)
+            LightFxRenderToTextureAvx512(dstPixels, dstPitch, bits, width, height, palette, lightPalette, lightBits);
+        }
+        else
+        {
+            for (uint32_t y = 0; y < height; y++)
             {
-                PaletteIndex src = bits[y * width + x];
-                uint32_t darkColour = palette[EnumValue(src)];
-                uint32_t lightColour = lightPalette[EnumValue(src)];
-                uint8_t lightIntensity = lightBits[y * width + x];
+                uintptr_t dstOffset = static_cast<uintptr_t>(y * dstPitch);
+                uint32_t* dst = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(dstPixels) + dstOffset);
+                for (uint32_t x = 0; x < width; x++)
+                {
+                    PaletteIndex src = bits[y * width + x];
+                    uint32_t darkColour = palette[EnumValue(src)];
+                    uint32_t lightColour = lightPalette[EnumValue(src)];
+                    uint8_t lightIntensity = lightBits[y * width + x];
 
-                uint32_t colour = 0;
-                if (lightIntensity == 0)
-                {
-                    colour = darkColour;
+                    uint32_t colour = 0;
+                    if (lightIntensity == 0)
+                    {
+                        colour = darkColour;
+                    }
+                    else
+                    {
+                        colour |= MixLight((darkColour >> 0) & 0xFF, (lightColour >> 0) & 0xFF, lightIntensity);
+                        colour |= MixLight((darkColour >> 8) & 0xFF, (lightColour >> 8) & 0xFF, lightIntensity) << 8;
+                        colour |= MixLight((darkColour >> 16) & 0xFF, (lightColour >> 16) & 0xFF, lightIntensity) << 16;
+                        colour |= MixLight((darkColour >> 24) & 0xFF, (lightColour >> 24) & 0xFF, lightIntensity) << 24;
+                    }
+                    *dst++ = colour;
                 }
-                else
-                {
-                    colour |= MixLight((darkColour >> 0) & 0xFF, (lightColour >> 0) & 0xFF, lightIntensity);
-                    colour |= MixLight((darkColour >> 8) & 0xFF, (lightColour >> 8) & 0xFF, lightIntensity) << 8;
-                    colour |= MixLight((darkColour >> 16) & 0xFF, (lightColour >> 16) & 0xFF, lightIntensity) << 16;
-                    colour |= MixLight((darkColour >> 24) & 0xFF, (lightColour >> 24) & 0xFF, lightIntensity) << 24;
-                }
-                *dst++ = colour;
             }
         }
     }

--- a/src/openrct2/drawing/PaletteMap.h
+++ b/src/openrct2/drawing/PaletteMap.h
@@ -55,6 +55,11 @@ namespace OpenRCT2::Drawing
         PaletteIndex& operator[](size_t index);
         PaletteIndex operator[](size_t index) const;
 
+        const PaletteIndex* data() const
+        {
+            return _data.data();
+        }
+
         PaletteIndex Blend(PaletteIndex src, PaletteIndex dst) const;
         void Copy(PaletteIndex dstIndex, const PaletteMap& src, PaletteIndex srcIndex, size_t length);
     };

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -521,18 +521,23 @@ void X8DrawingContext::FilterRect(
     if (paletteMap.has_value())
     {
         const auto& paletteEntries = paletteMap.value();
-        const int32_t scaled_width = width;
         const int32_t step = rt.LineStride();
 
-        // Fill the rectangle with the colours from the colour table
-        auto c = height;
-        for (int32_t i = 0; i < c; i++)
+        if (Platform::AVX512Available())
         {
-            PaletteIndex* nextdst = dst + step * i;
-            for (int32_t j = 0; j < scaled_width; j++)
+            FilterRectAvx512(dst, width, height, step, &paletteEntries[0]);
+        }
+        else
+        {
+            // Fill the rectangle with the colours from the colour table
+            for (int32_t i = 0; i < height; i++)
             {
-                auto index = *(nextdst + j);
-                *(nextdst + j) = paletteEntries[EnumValue(index)];
+                PaletteIndex* nextdst = dst + step * i;
+                for (int32_t j = 0; j < width; j++)
+                {
+                    auto index = *(nextdst + j);
+                    *(nextdst + j) = paletteEntries[EnumValue(index)];
+                }
             }
         }
     }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -10,6 +10,7 @@
 #include "X8DrawingEngine.h"
 
 #include "../Context.h"
+#include "../platform/Platform.h"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../core/Numerics.hpp"
@@ -525,7 +526,7 @@ void X8DrawingContext::FilterRect(
 
         if (Platform::AVX512Available())
         {
-            FilterRectAvx512(dst, width, height, step, &paletteEntries[0]);
+            FilterRectAvx512(dst, width, height, step, paletteEntries.data());
         }
         else
         {

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -10,13 +10,13 @@
 #include "X8DrawingEngine.h"
 
 #include "../Context.h"
-#include "../platform/Platform.h"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../core/Numerics.hpp"
 #include "../interface/Screenshot.h"
 #include "../interface/Viewport.h"
 #include "../interface/Window.h"
+#include "../platform/Platform.h"
 #include "../scenes/intro/IntroScene.h"
 #include "../ui/UiContext.h"
 #include "BlendColourMap.h"
@@ -586,7 +586,7 @@ void X8DrawingContext::DrawGlyph(RenderTarget& rt, const ImageId image, int32_t 
 }
 
 #ifndef DISABLE_TTF
-template<bool TUseHinting>
+template <bool TUseHinting>
 static void DrawTTFBitmapInternal(
     RenderTarget& rt, PaletteIndex colour, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
 {
@@ -655,7 +655,7 @@ static void DrawTTFBitmapInternal(
         dst += dstScanSkip;
     }
 }
-#endif // DISABLE_TTF
+#endif // DISABLE_TTT
 
 void X8DrawingContext::DrawTTFBitmap(
     RenderTarget& rt, const TextDrawInfo& info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -869,6 +869,7 @@
     <ClCompile Include="Date.cpp" />
     <ClCompile Include="Diagnostic.cpp" />
     <ClCompile Include="drawing\AVX2Drawing.cpp" />
+    <ClCompile Include="drawing\AVX512Drawing.cpp" />
     <ClCompile Include="drawing\BlendColourMap.cpp" />
     <ClCompile Include="drawing\Colour.cpp" />
     <ClCompile Include="drawing\ColourMap.cpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -869,7 +869,9 @@
     <ClCompile Include="Date.cpp" />
     <ClCompile Include="Diagnostic.cpp" />
     <ClCompile Include="drawing\AVX2Drawing.cpp" />
-    <ClCompile Include="drawing\AVX512Drawing.cpp" />
+    <ClCompile Include="drawing\AVX512Drawing.cpp">
+      <AdditionalOptions Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">/arch:AVX512 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="drawing\BlendColourMap.cpp" />
     <ClCompile Include="drawing\Colour.cpp" />
     <ClCompile Include="drawing\ColourMap.cpp" />

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -20,11 +20,13 @@
     #include <cpuid.h>
     #include <immintrin.h>
     #define OpenRCT2_CPUID_GNUC_X86
+    #define OPENRCT2_X86
 #elif defined(_MSC_VER) && (_MSC_VER >= 1500) && (defined(_M_X64) || defined(_M_IX86)) // VS2008
     #include <immintrin.h>
     #include <intrin.h>
     #include <nmmintrin.h>
     #define OpenRCT2_CPUID_MSVC_X86
+    #define OPENRCT2_X86
 #endif
 
 #include "../Context.h"

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -18,8 +18,10 @@
 
 #if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
     #include <cpuid.h>
+    #include <immintrin.h>
     #define OpenRCT2_CPUID_GNUC_X86
 #elif defined(_MSC_VER) && (_MSC_VER >= 1500) && (defined(_M_X64) || defined(_M_IX86)) // VS2008
+    #include <immintrin.h>
     #include <intrin.h>
     #include <nmmintrin.h>
     #define OpenRCT2_CPUID_MSVC_X86
@@ -251,6 +253,36 @@ namespace OpenRCT2::Platform
                 avxCPUSupport = (xcrFeatureMask & 0x6) || false;
             }
             return avxCPUSupport;
+        }
+    #endif
+#endif
+        return false;
+    }
+
+    bool AVX512Available()
+    {
+#ifdef OPENRCT2_X86
+    #if defined(OpenRCT2_CPUID_GNUC_X86) && (!defined(__FreeBSD__) || (__FreeBSD__ > 10))
+        return __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512bw") && __builtin_cpu_supports("avx512dq")
+            && __builtin_cpu_supports("avx512vl") && __builtin_cpu_supports("avx512vbmi");
+    #else
+        // AVX-512 Foundation support is declared as the 16th bit of EBX with CPUID(EAX = 7, ECX = 0).
+        uint32_t regs[4] = { 0 };
+        if (CPUIDX86(regs, 7))
+        {
+            // EBX: 16: AVX512F, 17: AVX512DQ, 30: AVX512BW, 31: AVX512VL
+            // ECX: 1: AVX512VBMI
+            constexpr uint32_t avx512MaskEBX = (1 << 16) | (1 << 17) | (1 << 30) | (1 << 31);
+            constexpr uint32_t avx512MaskECX = (1 << 1);
+            bool avx512CPUSupport = (regs[1] & avx512MaskEBX) == avx512MaskEBX && (regs[2] & avx512MaskECX) == avx512MaskECX;
+            if (avx512CPUSupport)
+            {
+                // Need to check if OS also supports the registers.
+                // For AVX-512 we need XMM (bit 1), YMM (bit 2), Opmask (bit 5), ZMM_Hi256 (bit 6), and Hi16_ZMM (bit 7).
+                uint64_t xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+                avx512CPUSupport = (xcrFeatureMask & 0xE6) == 0xE6;
+            }
+            return avx512CPUSupport;
         }
     #endif
 #endif

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -43,9 +43,9 @@
 #include <thread>
 
 #ifdef _WIN32
-static constexpr std::array _prohibitedCharacters = { '<', '>', '*', '\\', ':', '|', '?', '"', '/' };
+static constexpr std::array kProhibitedCharacters = { '<', '>', '*', '\\', ':', '|', '?', '"', '/' };
 #else
-static constexpr std::array _prohibitedCharacters = { '/' };
+static constexpr std::array kProhibitedCharacters = { '/' };
 #endif
 
 namespace OpenRCT2::Platform
@@ -170,7 +170,7 @@ namespace OpenRCT2::Platform
         std::replace_if(
             sanitised.begin(), sanitised.end(),
             [](const std::string::value_type& ch) -> bool {
-                return std::find(_prohibitedCharacters.begin(), _prohibitedCharacters.end(), ch) != _prohibitedCharacters.end();
+                return std::find(kProhibitedCharacters.begin(), kProhibitedCharacters.end(), ch) != kProhibitedCharacters.end();
             },
             '_');
         sanitised = String::trim(sanitised);
@@ -179,7 +179,7 @@ namespace OpenRCT2::Platform
 
     bool IsFilenameValid(u8string_view fileName)
     {
-        return fileName.find_first_of(_prohibitedCharacters.data(), 0, _prohibitedCharacters.size()) == fileName.npos;
+        return fileName.find_first_of(kProhibitedCharacters.data(), 0, kProhibitedCharacters.size()) == fileName.npos;
     }
 
 #ifndef __ANDROID__

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -230,6 +230,7 @@ namespace OpenRCT2::Platform
 
     bool SSE41Available();
     bool AVX2Available();
+    bool AVX512Available();
 
     std::vector<std::string_view> GetSearchablePathsRCT1();
     std::vector<std::string_view> GetSearchablePathsRCT2();

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -179,8 +179,7 @@ namespace OpenRCT2::Platform
 
     SteamPaths GetSteamPaths();
     bool triggerSteamDownload();
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__NetBSD__)              \
-    || defined(__HAIKU__)
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__NetBSD__)                  || defined(__HAIKU__)
     std::string GetEnvironmentPath(const char* name);
     std::string GetHomePath();
 #endif


### PR DESCRIPTION
Introduced AVX-512 optimizations for performance-critical drawing routines in OpenRCT2. These optimizations leverage 512-bit ZMM registers and advanced instructions like VBMI for palette lookups, which significantly benefit CPUs like Zen 4. Added comprehensive runtime detection and fallback logic to maintain compatibility.

---
*PR created automatically by Jules for task [18163238334253134255](https://jules.google.com/task/18163238334253134255) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AVX-512–accelerated drawing, masking, and light-effect rendering on supported x86 systems.
  * Runtime capability query to select AVX-512 optimized code paths when available.

* **Chores**
  * Build/project settings updated to enable AVX-512 compilation where applicable.
  * Added a palette data accessor to support optimized routines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janisozaur/OpenRCT2/pull/100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->