### PR TITLE
Fix opening URLs and folders on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           # Keep win32 on vs2022 for Windows 7 compatibility.
           # See https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners
           - platform: win32
-            runs_on: windows-2025
+            runs_on: windows-2022
           - platform: x64
             runs_on: windows-2025-vs2026
           - platform: arm64

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -118,7 +118,7 @@ public class GameActivity extends SDLActivity {
         return new String[0];
     }
 
-    public void openURL(String url) {
+    public void launchURL(String url) {
         try {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             startActivity(intent);
@@ -127,7 +127,7 @@ public class GameActivity extends SDLActivity {
         }
     }
 
-    public void openFolder(String path) {
+    public void launchFolder(String path) {
         try {
             File file = new File(path);
             Intent intent = new Intent(Intent.ACTION_VIEW);

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -1,14 +1,18 @@
 package io.openrct2;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
 import android.icu.util.Currency;
 import android.icu.util.LocaleData;
 import android.icu.util.ULocale;
+import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 import android.view.View;
 
 import org.libsdl.app.SDLActivity;
 
+import java.io.File;
 import java.util.Locale;
 
 public class GameActivity extends SDLActivity {
@@ -112,5 +116,30 @@ public class GameActivity extends SDLActivity {
             return getIntent().getStringArrayExtra("commandLineArgs");
         }
         return new String[0];
+    }
+
+    public void openURL(String url) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            startActivity(intent);
+        } catch (Exception e) {
+            Log.e("OpenRCT2", "Failed to open URL: " + url, e);
+        }
+    }
+
+    public void openFolder(String path) {
+        try {
+            File file = new File(path);
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            Uri uri = Uri.fromFile(file);
+            intent.setDataAndType(uri, "resource/folder");
+            if (intent.resolveActivity(getPackageManager()) != null) {
+                startActivity(intent);
+            } else {
+                Log.w("OpenRCT2", "No activity found to open folder: " + path);
+            }
+        } catch (Exception e) {
+            Log.e("OpenRCT2", "Failed to open folder: " + path, e);
+        }
     }
 }

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -75,11 +75,32 @@ namespace OpenRCT2::Ui
 
         void OpenFolder(const std::string& path) override
         {
+            JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+            jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+            jclass activityClass = env->GetObjectClass(activity);
+            jmethodID openFolderMethod = env->GetMethodID(activityClass, "openFolder", "(Ljava/lang/String;)V");
+
+            jstring jPath = env->NewStringUTF(path.c_str());
+            env->CallVoidMethod(activity, openFolderMethod, jPath);
+
+            env->DeleteLocalRef(jPath);
+            env->DeleteLocalRef(activityClass);
+            env->DeleteLocalRef(activity);
         }
 
         void OpenURL(const std::string& url) override
         {
-            LOG_WARNING("Function %s at %s:%d is a stub.", __PRETTY_FUNCTION__, __FILE__, __LINE__);
+            JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+            jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+            jclass activityClass = env->GetObjectClass(activity);
+            jmethodID openURLMethod = env->GetMethodID(activityClass, "openURL", "(Ljava/lang/String;)V");
+
+            jstring jUrl = env->NewStringUTF(url.c_str());
+            env->CallVoidMethod(activity, openURLMethod, jUrl);
+
+            env->DeleteLocalRef(jUrl);
+            env->DeleteLocalRef(activityClass);
+            env->DeleteLocalRef(activity);
         }
 
         bool HasFilePicker() const override

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -77,13 +77,20 @@ namespace OpenRCT2::Ui
         {
             JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
             jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+            if (activity == nullptr)
+            {
+                return;
+            }
+
             jclass activityClass = env->GetObjectClass(activity);
             jmethodID launchFolderMethod = env->GetMethodID(activityClass, "launchFolder", "(Ljava/lang/String;)V");
+            if (launchFolderMethod != nullptr)
+            {
+                jstring jPath = env->NewStringUTF(path.c_str());
+                env->CallVoidMethod(activity, launchFolderMethod, jPath);
+                env->DeleteLocalRef(jPath);
+            }
 
-            jstring jPath = env->NewStringUTF(path.c_str());
-            env->CallVoidMethod(activity, launchFolderMethod, jPath);
-
-            env->DeleteLocalRef(jPath);
             env->DeleteLocalRef(activityClass);
             env->DeleteLocalRef(activity);
         }
@@ -92,13 +99,20 @@ namespace OpenRCT2::Ui
         {
             JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
             jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+            if (activity == nullptr)
+            {
+                return;
+            }
+
             jclass activityClass = env->GetObjectClass(activity);
             jmethodID launchURLMethod = env->GetMethodID(activityClass, "launchURL", "(Ljava/lang/String;)V");
+            if (launchURLMethod != nullptr)
+            {
+                jstring jUrl = env->NewStringUTF(url.c_str());
+                env->CallVoidMethod(activity, launchURLMethod, jUrl);
+                env->DeleteLocalRef(jUrl);
+            }
 
-            jstring jUrl = env->NewStringUTF(url.c_str());
-            env->CallVoidMethod(activity, launchURLMethod, jUrl);
-
-            env->DeleteLocalRef(jUrl);
             env->DeleteLocalRef(activityClass);
             env->DeleteLocalRef(activity);
         }

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -78,10 +78,10 @@ namespace OpenRCT2::Ui
             JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
             jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
             jclass activityClass = env->GetObjectClass(activity);
-            jmethodID openFolderMethod = env->GetMethodID(activityClass, "openFolder", "(Ljava/lang/String;)V");
+            jmethodID launchFolderMethod = env->GetMethodID(activityClass, "launchFolder", "(Ljava/lang/String;)V");
 
             jstring jPath = env->NewStringUTF(path.c_str());
-            env->CallVoidMethod(activity, openFolderMethod, jPath);
+            env->CallVoidMethod(activity, launchFolderMethod, jPath);
 
             env->DeleteLocalRef(jPath);
             env->DeleteLocalRef(activityClass);
@@ -93,10 +93,10 @@ namespace OpenRCT2::Ui
             JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
             jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
             jclass activityClass = env->GetObjectClass(activity);
-            jmethodID openURLMethod = env->GetMethodID(activityClass, "openURL", "(Ljava/lang/String;)V");
+            jmethodID launchURLMethod = env->GetMethodID(activityClass, "launchURL", "(Ljava/lang/String;)V");
 
             jstring jUrl = env->NewStringUTF(url.c_str());
-            env->CallVoidMethod(activity, openURLMethod, jUrl);
+            env->CallVoidMethod(activity, launchURLMethod, jUrl);
 
             env->DeleteLocalRef(jUrl);
             env->DeleteLocalRef(activityClass);


### PR DESCRIPTION
This PR implements the previously stubbed `OpenURL` and `OpenFolder` methods in the Android UI context. It adds corresponding Java methods in `GameActivity` that use Android Intents to handle these actions, allowing the download button in the changelog (and other links) to function correctly.

---
*PR created automatically by Jules for task [1411126430726096512](https://jules.google.com/task/1411126430726096512) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented URL opening functionality on Android
  * Implemented folder opening functionality on Android

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janisozaur/OpenRCT2/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->