### PR TITLE
Improve map compression diagnostics and reliability

### DIFF
--- a/src/openrct2/core/Compression.cpp
+++ b/src/openrct2/core/Compression.cpp
@@ -210,7 +210,9 @@ namespace OpenRCT2::Compression
                 ret = ZSTD_compressStream2(ctx.get(), &output, &input, sourceBuf ? ZSTD_e_continue : ZSTD_e_end);
                 if (ZSTD_isError(ret))
                 {
-                    LOG_ERROR("Failed to compress data with error: %s", ZSTD_getErrorName(ret));
+                    LOG_ERROR(
+                        "Failed to compress data with error: %s (in_pos=%zu, in_size=%zu, out_pos=%zu, out_size=%zu)",
+                        ZSTD_getErrorName(ret), input.pos, input.size, output.pos, output.size);
                     return false;
                 }
 
@@ -257,7 +259,9 @@ namespace OpenRCT2::Compression
                 ret = ZSTD_decompressStream(ctx.get(), &output, &input);
                 if (ZSTD_isError(ret))
                 {
-                    LOG_ERROR("Failed to compress data with error: %s", ZSTD_getErrorName(ret));
+                    LOG_ERROR(
+                        "Failed to decompress data with error: %s (in_pos=%zu, in_size=%zu, out_pos=%zu, out_size=%zu)",
+                        ZSTD_getErrorName(ret), input.pos, input.size, output.pos, output.size);
                     return false;
                 }
 

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../Diagnostic.h"
 #include "../core/Compression.h"
 #include "../world/Location.hpp"
 #include "Crypt.h"
@@ -179,8 +180,43 @@ namespace OpenRCT2
 
                     if (compressStatus && compressed.GetLength() < _buffer.GetLength())
                     {
-                        _buffer = std::move(compressed);
-                        _header.compressedSize = _buffer.GetLength();
+                        // Verify compressed data
+                        MemoryStream decompressed;
+                        bool decompressStatus = false;
+                        compressed.SetPosition(0);
+                        if (_header.compression == CompressionType::gzip)
+                        {
+                            decompressStatus = Compression::zlibDecompress(
+                                compressed, compressed.GetLength(), decompressed, _header.uncompressedSize,
+                                Compression::ZlibHeaderType::gzip);
+                        }
+                        else if (_header.compression == CompressionType::zstd)
+                        {
+                            decompressStatus = Compression::zstdDecompress(
+                                compressed, compressed.GetLength(), decompressed, _header.uncompressedSize);
+                        }
+
+                        if (decompressStatus && decompressed.GetLength() == _header.uncompressedSize)
+                        {
+                            auto verifyChecksum = Crypt::FNV1a(decompressed.GetData(), decompressed.GetLength());
+                            if (verifyChecksum == _header.fnv1a)
+                            {
+                                _buffer = std::move(compressed);
+                                _header.compressedSize = _buffer.GetLength();
+                            }
+                            else
+                            {
+                                LOG_ERROR("OrcaStream: Compression verification failed (checksum mismatch), storing uncompressed data instead.");
+                                _header.compression = CompressionType::none;
+                                _header.compressedSize = _header.uncompressedSize;
+                            }
+                        }
+                        else
+                        {
+                            LOG_ERROR("OrcaStream: Compression verification failed (decompression error), storing uncompressed data instead.");
+                            _header.compression = CompressionType::none;
+                            _header.compressedSize = _header.uncompressedSize;
+                        }
                     }
                     else
                     {

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -128,7 +128,7 @@ namespace OpenRCT2
                 // with a verison number of 0 may be one of these, and don't check their hashes.
                 if (_header.targetVersion > 0)
                 {
-                    auto checksum = Crypt::FNV1a(_buffer.GetData(), _buffer.GetLength());
+                    auto checksum = Crypt::FNV1a(_buffer.GetData(), static_cast<size_t>(_buffer.GetLength()));
                     if (checksum != _header.fnv1a)
                         throw IOException("Checksum is not valid!");
                 }
@@ -151,7 +151,7 @@ namespace OpenRCT2
                 _header.numChunks = static_cast<uint32_t>(_chunks.size());
                 _header.uncompressedSize = _buffer.GetLength();
                 _header.compressedSize = _buffer.GetLength();
-                _header.fnv1a = Crypt::FNV1a(_buffer.GetData(), _buffer.GetLength());
+                _header.fnv1a = Crypt::FNV1a(_buffer.GetData(), static_cast<size_t>(_buffer.GetLength()));
 
                 if (_compressionLevel == Compression::kNoCompressionLevel)
                     _header.compression = CompressionType::none;
@@ -198,7 +198,8 @@ namespace OpenRCT2
 
                         if (decompressStatus && decompressed.GetLength() == _header.uncompressedSize)
                         {
-                            auto verifyChecksum = Crypt::FNV1a(decompressed.GetData(), decompressed.GetLength());
+                            auto verifyChecksum = Crypt::FNV1a(
+                                decompressed.GetData(), static_cast<size_t>(decompressed.GetLength()));
                             if (verifyChecksum == _header.fnv1a)
                             {
                                 _buffer = std::move(compressed);

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -206,14 +206,18 @@ namespace OpenRCT2
                             }
                             else
                             {
-                                LOG_ERROR("OrcaStream: Compression verification failed (checksum mismatch), storing uncompressed data instead.");
+                                LOG_ERROR(
+                                    "OrcaStream: Compression verification failed (checksum mismatch), storing uncompressed "
+                                    "data instead.");
                                 _header.compression = CompressionType::none;
                                 _header.compressedSize = _header.uncompressedSize;
                             }
                         }
                         else
                         {
-                            LOG_ERROR("OrcaStream: Compression verification failed (decompression error), storing uncompressed data instead.");
+                            LOG_ERROR(
+                                "OrcaStream: Compression verification failed (decompression error), storing uncompressed data "
+                                "instead.");
                             _header.compression = CompressionType::none;
                             _header.compressedSize = _header.uncompressedSize;
                         }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2882,6 +2882,37 @@ namespace OpenRCT2::Network
         catch (const std::exception& e)
         {
             Console::Error::WriteLine("Unable to read map from server: %s", e.what());
+
+            // Save the corrupted map data for debugging.
+            if (stream != nullptr)
+            {
+                try
+                {
+                    std::string outputPath = GetContext().GetPlatformEnvironment().GetDirectoryPath(
+                        DirBase::user, DirId::desyncLogs);
+
+                    Path::CreateDirectory(outputPath);
+
+                    char uniqueFileName[128] = {};
+                    snprintf(
+                        uniqueFileName, sizeof(uniqueFileName), "map_corruption_%llu.bin",
+                        static_cast<long long unsigned>(Platform::GetDatetimeNowUTC()));
+
+                    std::string outputFile = Path::Combine(outputPath, uniqueFileName);
+
+                    auto fs = FileStream(outputFile, FileMode::write);
+                    auto pos = stream->GetPosition();
+                    stream->SetPosition(0);
+                    fs.CopyFromStream(*stream, stream->GetLength());
+                    stream->SetPosition(pos);
+
+                    LOG_INFO("Wrote corrupted map data to '%s'", outputFile.c_str());
+                }
+                catch (const std::exception& ex)
+                {
+                    LOG_ERROR("Failed to write corrupted map data: %s", ex.what());
+                }
+            }
         }
         return result;
     }

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -208,6 +208,10 @@ namespace OpenRCT2
             ReadWritePluginStorageChunk(gameState, os);
             ReadWritePreviewChunk(gameState, os);
             ReadWritePackedObjectsChunk(os);
+
+            LOG_INFO(
+                "Park saved: uncompressed=%llu, compressed=%llu, type=%u", header.uncompressedSize,
+                header.compressedSize, static_cast<uint32_t>(header.compression));
         }
 
         void Save(GameState_t& gameState, const std::string_view path, int16_t compressionLevel)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -210,8 +210,8 @@ namespace OpenRCT2
             ReadWritePackedObjectsChunk(os);
 
             LOG_INFO(
-                "Park saved: uncompressed=%llu, compressed=%llu, type=%u", header.uncompressedSize,
-                header.compressedSize, static_cast<uint32_t>(header.compression));
+                "Park saved: uncompressed=%llu, compressed=%llu, type=%u", header.uncompressedSize, header.compressedSize,
+                static_cast<uint32_t>(header.compression));
         }
 
         void Save(GameState_t& gameState, const std::string_view path, int16_t compressionLevel)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -210,8 +210,9 @@ namespace OpenRCT2
             ReadWritePackedObjectsChunk(os);
 
             LOG_INFO(
-                "Park saved: uncompressed=%llu, compressed=%llu, type=%u", header.uncompressedSize, header.compressedSize,
-                static_cast<uint32_t>(header.compression));
+                "Park saved: uncompressed=%llu, compressed=%llu, type=%u",
+                static_cast<unsigned long long>(header.uncompressedSize),
+                static_cast<unsigned long long>(header.compressedSize), static_cast<uint32_t>(header.compression));
         }
 
         void Save(GameState_t& gameState, const std::string_view path, int16_t compressionLevel)


### PR DESCRIPTION
This change addresses Zstd decompression errors during map transfer. It adds immediate verification after compression in OrcaStream, improved logging in Compression.cpp, and automatic dumping of corrupted map data on the client for better tracing.

---
*PR created automatically by Jules for task [16386498223374824056](https://jules.google.com/task/16386498223374824056) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced compression error diagnostics with detailed buffer and error information
  * Added data integrity verification for compressed save files with checksum validation

* **Chores**
  * Improved multiplayer debugging by automatically persisting corrupted map data
  * Added detailed save statistics logging including compression metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janisozaur/OpenRCT2/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->