### PR TITLE
Add CodeQL query for non-deterministic GameActions detection

### DIFF
--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -22,7 +22,7 @@ import cpp
 class NonDeterministicFunction extends Function {
   NonDeterministicFunction() {
     this.getName() = ["UtilRand", "UtilRandNormalDistributed", "rand"] or
-    this.getQualifiedName().matches("%::rand") or
+    this.getQualifiedName() = "std::rand" or
     // random_device::operator()
     exists(MemberFunction m |
       m = this and
@@ -38,35 +38,38 @@ class NonDeterministicFunction extends Function {
  */
 class GameActionMethod extends MemberFunction {
   GameActionMethod() {
-    exists(MemberFunction base |
-      base = this.getAnOverriddenFunction*() and
-      base.getDeclaringType().getName() = "GameAction" and
-      base.getName() = ["Execute", "Query"]
+    (this.getName() = "Execute" or this.getName() = "Query") and
+    exists(Class c |
+      c = this.getDeclaringType() and
+      (
+        c.getName() = "GameAction" or
+        c.getABaseClass+().getName() = "GameAction"
+      )
     )
   }
 }
 
 /**
  * Functions that are considered "barriers" because they only affect local client state
- * or are part of the UI/Audio systems which are inherently non-deterministic but
- * shouldn't be reached from deterministic game logic (if they are, it's usually
- * a side effect like closing a window).
+ * or are part of the UI/Audio systems which are inherently non-deterministic.
  */
 predicate isBarrier(Function f) {
-  f.getQualifiedName().matches("OpenRCT2::Audio::%") or
-  f.getQualifiedName().matches("OpenRCT2::Ui::%") or
+  f.getQualifiedName().matches("%Audio::%") or
+  f.getQualifiedName().matches("%Ui::%") or
   f.getName() = [
     "GetTitleMusicDescriptor", "ApplyStyle", "Load", "onClose", "onMouseUp",
     "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseWheel",
     "onDraw", "onUpdate", "onPrepareDraw", "onPeriodicUpdate", "ShowError",
     "PlayTitleMusic", "GameLoadOrQuitNoSavePrompt", "SetActiveScene", "TitleInitialise",
-    "Resume", "ErrorOpen", "ResetObjects"
+    "Resume", "ErrorOpen", "ResetObjects", "InvalidateByNumber", "CloseByNumber",
+    "CloseByCondition", "CloseByClass", "onPrepareDraw", "onUpdate"
   ] or
   exists(Type t | t = f.(MemberFunction).getDeclaringType() |
-    t.getName() = ["TitleScene", "WindowManager", "ProgressWindow", "WindowBase", "Scene", "Audio"]
+    t.getName().matches("%Scene") or
+    t.getName() = ["WindowManager", "ProgressWindow", "WindowBase", "Audio"]
   ) or
   // Exclude common UI/Local-only paths
-  f.getFile().getRelativePath().matches("src/openrct2-ui/%")
+  f.getFile().getRelativePath().matches("%openrct2-ui/%")
 }
 
 /**
@@ -89,10 +92,7 @@ module CallGraphPath {
           m = call.getTarget() and
           callee.(MemberFunction).getAnOverriddenFunction+() = m and
           // Avoid noise from broad interfaces that would connect unrelated actions
-          not (
-            m.getDeclaringType().getName() = "GameAction" and
-            m.getName() = ["Execute", "Query"]
-          )
+          not m.getDeclaringType().getName() = "GameAction"
         )
       ) and
       not isBarrier(callee)

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -38,12 +38,31 @@ class NonDeterministicFunction extends Function {
  */
 class GameActionMethod extends MemberFunction {
   GameActionMethod() {
-    exists(MemberFunction base |
-      base.getDeclaringType().hasQualifiedName("OpenRCT2::GameActions", "GameAction") and
-      (base.getName() = "Execute" or base.getName() = "Query") and
-      this.getAnOverriddenFunction*() = base
-    )
+    this.getAnOverriddenFunction*().hasQualifiedName("OpenRCT2", "GameActions", "GameAction", ["Execute", "Query"])
   }
+}
+
+/**
+ * Functions that are considered "barriers" because they only affect local client state
+ * or are part of the UI/Audio systems which are inherently non-deterministic but
+ * shouldn't be reached from deterministic game logic (if they are, it's usually
+ * a side effect like closing a window).
+ */
+predicate isBarrier(Function f) {
+  f.hasQualifiedName("OpenRCT2", "Audio", _, _) or
+  f.hasQualifiedName("OpenRCT2", "Ui", _, _) or
+  f.hasQualifiedName("OpenRCT2", "Audio", _) or
+  f.hasQualifiedName("OpenRCT2", "Ui", _) or
+  f.getName() = [
+    "GetTitleMusicDescriptor", "ApplyStyle", "Load", "onClose", "onMouseUp",
+    "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseWheel",
+    "onDraw", "onUpdate", "onPrepareDraw", "onPeriodicUpdate"
+  ] or
+  exists(Type t | t = f.(MemberFunction).getDeclaringType() |
+    t.getName() = ["TitleScene", "WindowManager", "ProgressWindow"]
+  ) or
+  // Exclude common UI/Local-only paths
+  f.getFile().getRelativePath().matches("src/openrct2-ui/%")
 }
 
 /**
@@ -56,6 +75,7 @@ module CallGraphPath {
   query predicate edges(Function caller, Function callee) {
     exists(Call call |
       call.getEnclosingFunction() = caller and
+      not isBarrier(caller) and
       (
         // Static/Direct call
         callee = call.getTarget()
@@ -64,12 +84,14 @@ module CallGraphPath {
         exists(MemberFunction m |
           m = call.getTarget() and
           callee.(MemberFunction).getAnOverriddenFunction+() = m and
-          // Avoid noise from broad interfaces
-          not m.getDeclaringType().hasQualifiedName("OpenRCT2::GameActions", "GameAction")
+          // Avoid noise from broad interfaces that would connect unrelated actions
+          not m.hasQualifiedName("OpenRCT2", "GameActions", "GameAction", ["Execute", "Query"])
         )
       )
     )
   }
+
+  query predicate nodes(Function f) { any() }
 
   class Node = Function;
 }

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -22,11 +22,11 @@ import cpp
 class NonDeterministicFunction extends Function {
   NonDeterministicFunction() {
     this.getName() = ["UtilRand", "UtilRandNormalDistributed", "rand"] or
-    this.hasQualifiedName("std", "rand") or
+    this.getQualifiedName().matches("%::rand") or
     // random_device::operator()
     exists(MemberFunction m |
       m = this and
-      m.getDeclaringType().hasQualifiedName("std", "random_device") and
+      m.getDeclaringType().getName() = "random_device" and
       m.getName() = "operator()"
     )
   }
@@ -38,7 +38,11 @@ class NonDeterministicFunction extends Function {
  */
 class GameActionMethod extends MemberFunction {
   GameActionMethod() {
-    this.getAnOverriddenFunction*().hasQualifiedName("OpenRCT2", "GameActions", "GameAction", ["Execute", "Query"])
+    exists(MemberFunction base |
+      base = this.getAnOverriddenFunction*() and
+      base.getDeclaringType().getName() = "GameAction" and
+      base.getName() = ["Execute", "Query"]
+    )
   }
 }
 
@@ -49,17 +53,17 @@ class GameActionMethod extends MemberFunction {
  * a side effect like closing a window).
  */
 predicate isBarrier(Function f) {
-  f.hasQualifiedName("OpenRCT2", "Audio", _, _) or
-  f.hasQualifiedName("OpenRCT2", "Ui", _, _) or
-  f.hasQualifiedName("OpenRCT2", "Audio", _) or
-  f.hasQualifiedName("OpenRCT2", "Ui", _) or
+  f.getQualifiedName().matches("OpenRCT2::Audio::%") or
+  f.getQualifiedName().matches("OpenRCT2::Ui::%") or
   f.getName() = [
     "GetTitleMusicDescriptor", "ApplyStyle", "Load", "onClose", "onMouseUp",
     "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseWheel",
-    "onDraw", "onUpdate", "onPrepareDraw", "onPeriodicUpdate"
+    "onDraw", "onUpdate", "onPrepareDraw", "onPeriodicUpdate", "ShowError",
+    "PlayTitleMusic", "GameLoadOrQuitNoSavePrompt", "SetActiveScene", "TitleInitialise",
+    "Resume", "ErrorOpen", "ResetObjects"
   ] or
   exists(Type t | t = f.(MemberFunction).getDeclaringType() |
-    t.getName() = ["TitleScene", "WindowManager", "ProgressWindow"]
+    t.getName() = ["TitleScene", "WindowManager", "ProgressWindow", "WindowBase", "Scene", "Audio"]
   ) or
   // Exclude common UI/Local-only paths
   f.getFile().getRelativePath().matches("src/openrct2-ui/%")
@@ -85,9 +89,13 @@ module CallGraphPath {
           m = call.getTarget() and
           callee.(MemberFunction).getAnOverriddenFunction+() = m and
           // Avoid noise from broad interfaces that would connect unrelated actions
-          not m.hasQualifiedName("OpenRCT2", "GameActions", "GameAction", ["Execute", "Query"])
+          not (
+            m.getDeclaringType().getName() = "GameAction" and
+            m.getName() = ["Execute", "Query"]
+          )
         )
-      )
+      ) and
+      not isBarrier(callee)
     )
   }
 
@@ -98,8 +106,6 @@ module CallGraphPath {
 
 import CallGraphPath
 
-from GameActionMethod source, NonDeterministicFunction sink, Call call
-where
-  CallGraphPath::edges*(source, call.getEnclosingFunction()) and
-  call.getTarget() = sink
-select call, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."
+from GameActionMethod source, NonDeterministicFunction sink
+where CallGraphPath::edges*(source, sink)
+select sink, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -22,11 +22,16 @@ import cpp
 class NonDeterministicFunction extends Function {
   NonDeterministicFunction() {
     this.getName() = ["UtilRand", "UtilRandNormalDistributed", "rand"] or
-    this.getQualifiedName() = "std::rand" or
-    // random_device::operator()
+    this.getQualifiedName().matches("%::rand") or
+    // Catch C++ standard library random number generators
     exists(MemberFunction m |
       m = this and
-      m.getDeclaringType().getName() = "random_device" and
+      m.getDeclaringType().getName().matches("%random_device%") and
+      m.getName() = "operator()"
+    ) or
+    exists(MemberFunction m |
+      m = this and
+      m.getDeclaringType().getName().matches("%mersenne_twister_engine%") and
       m.getName() = "operator()"
     )
   }
@@ -41,10 +46,7 @@ class GameActionMethod extends MemberFunction {
     (this.getName() = "Execute" or this.getName() = "Query") and
     exists(Class c |
       c = this.getDeclaringType() and
-      (
-        c.getName() = "GameAction" or
-        c.getABaseClass+().getName() = "GameAction"
-      )
+      (c.getName() = "GameAction" or c.getABaseClass+().getName() = "GameAction")
     )
   }
 }
@@ -57,55 +59,55 @@ predicate isBarrier(Function f) {
   f.getQualifiedName().matches("%Audio::%") or
   f.getQualifiedName().matches("%Ui::%") or
   f.getName() = [
-    "GetTitleMusicDescriptor", "ApplyStyle", "Load", "onClose", "onMouseUp",
-    "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseWheel",
-    "onDraw", "onUpdate", "onPrepareDraw", "onPeriodicUpdate", "ShowError",
-    "PlayTitleMusic", "GameLoadOrQuitNoSavePrompt", "SetActiveScene", "TitleInitialise",
-    "Resume", "ErrorOpen", "ResetObjects", "InvalidateByNumber", "CloseByNumber",
-    "CloseByCondition", "CloseByClass", "onPrepareDraw", "onUpdate"
+    "GetTitleMusicDescriptor", "PlayTitleMusic", "Load", "onClose",
+    "GameLoadOrQuitNoSavePrompt", "SetActiveScene", "TitleInitialise",
+    "ShowError", "ErrorOpen", "ResetObjects", "InvalidateByNumber",
+    "CloseByNumber", "CloseByCondition", "CloseByClass", "onPrepareDraw", "onUpdate"
   ] or
-  exists(Type t | t = f.(MemberFunction).getDeclaringType() |
-    t.getName().matches("%Scene") or
-    t.getName() = ["WindowManager", "ProgressWindow", "WindowBase", "Audio"]
-  ) or
-  // Exclude common UI/Local-only paths
+  // Exclude everything in openrct2-ui directory
   f.getFile().getRelativePath().matches("%openrct2-ui/%")
 }
 
 /**
- * A module for tracing call paths.
+ * Predicate representing an edge in the call graph.
  */
-module CallGraphPath {
-  /**
-   * Predicate to follow the call graph, including virtual calls.
-   */
-  query predicate edges(Function caller, Function callee) {
-    exists(Call call |
-      call.getEnclosingFunction() = caller and
-      not isBarrier(caller) and
-      (
-        // Static/Direct call
-        callee = call.getTarget()
-        or
-        // Virtual call: follow overrides, but avoid the generic dispatch noise through GameAction base
-        exists(MemberFunction m |
-          m = call.getTarget() and
-          callee.(MemberFunction).getAnOverriddenFunction+() = m and
-          // Avoid noise from broad interfaces that would connect unrelated actions
-          not m.getDeclaringType().getName() = "GameAction"
-        )
-      ) and
-      not isBarrier(callee)
+predicate callEdge(Function a, Function b) {
+  exists(Call c |
+    c.getEnclosingFunction() = a and
+    (
+      b = c.getTarget() or
+      b = c.getTarget().(MemberFunction).getAnOverriddenFunction+()
+    ) and
+    // Block virtual dispatch noise through the base GameAction class.
+    // This prevents jumping between unrelated actions via central dispatchers.
+    not (
+      c.getTarget().getName() = ["Execute", "Query"] and
+      c.getTarget().(MemberFunction).getDeclaringType().getName() = "GameAction"
     )
-  }
-
-  query predicate nodes(Function f) { any() }
-
-  class Node = Function;
+  )
 }
 
-import CallGraphPath
+/**
+ * Module required for path-problem queries.
+ */
+module GameActionPathGraph {
+  /**
+   * Predicate for edges in the path.
+   */
+  query predicate edges(Function a, Function b) {
+    callEdge(a, b) and
+    not isBarrier(a) and
+    not isBarrier(b)
+  }
+
+  /**
+   * Predicate for nodes in the path.
+   */
+  query predicate nodes(Function f) { any() }
+}
+
+import GameActionPathGraph
 
 from GameActionMethod source, NonDeterministicFunction sink
-where CallGraphPath::edges*(source, sink)
-select sink, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."
+where edges*(source, sink)
+select sink, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from " + source.getQualifiedName() + "."

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -21,14 +21,16 @@ import cpp
  */
 class NonDeterministicFunction extends Function {
   NonDeterministicFunction() {
-    this.hasGlobalName("UtilRand") or
-    this.hasGlobalName("UtilRandNormalDistributed") or
+    (
+      this.getName() = "UtilRand" or
+      this.getName() = "UtilRandNormalDistributed"
+    ) or
     this.hasGlobalName("rand") or
     this.hasQualifiedName("std", "rand") or
     // random_device::operator()
-    exists(Method m |
+    exists(MemberFunction m |
       m = this and
-      m.getDeclaringClass().hasQualifiedName("std", "random_device") and
+      m.getDeclaringType().hasQualifiedName("std", "random_device") and
       m.getName() = "operator()"
     )
   }
@@ -38,13 +40,12 @@ class NonDeterministicFunction extends Function {
  * The Execute or Query methods of a GameAction.
  * These are the entry points for game state changes or queries that must be deterministic.
  */
-class GameActionMethod extends Method {
+class GameActionMethod extends MemberFunction {
   GameActionMethod() {
-    exists(Method base |
-      // GameAction is in OpenRCT2::GameActions namespace as per file content
-      base.getDeclaringClass().hasQualifiedName("OpenRCT2::GameActions", "GameAction") and
+    exists(MemberFunction base |
+      base.getDeclaringType().hasQualifiedName("OpenRCT2::GameActions", "GameAction") and
       (base.getName() = "Execute" or base.getName() = "Query") and
-      this.getAnOverriddenMethod*() = base
+      this.getAnOverriddenFunction*() = base
     )
   }
 }
@@ -60,9 +61,9 @@ predicate calls(Function caller, Function callee) {
       callee = call.getTarget()
       or
       // Virtual call: if we call a method, any of its overrides could be the actual callee.
-      exists(Method m |
+      exists(MemberFunction m |
         m = call.getTarget() and
-        callee.(Method).getAnOverriddenMethod+() = m
+        callee.(MemberFunction).getAnOverriddenFunction+() = m
       )
     )
   )

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -4,7 +4,7 @@
  *              random functions like UtilRand or UtilRandNormalDistributed from a GameAction's
  *              Execute or Query method (or any function they call) can lead to state
  *              desyncs in multiplayer.
- * @kind problem
+ * @kind path-problem
  * @problem.severity error
  * @precision high
  * @id cpp/openrct2/non-deterministic-game-action
@@ -51,27 +51,33 @@ class GameActionMethod extends MemberFunction {
 }
 
 /**
- * Predicate to follow the call graph, including virtual calls.
+ * A module for tracing call paths.
  */
-predicate calls(Function caller, Function callee) {
-  exists(Call call |
-    call.getEnclosingFunction() = caller and
-    (
-      // Static/Direct call
-      callee = call.getTarget()
-      or
-      // Virtual call: if we call a method, any of its overrides could be the actual callee.
-      exists(MemberFunction m |
-        m = call.getTarget() and
-        callee.(MemberFunction).getAnOverriddenFunction+() = m
+module CallGraphPath {
+  /**
+   * Predicate to follow the call graph, including virtual calls.
+   */
+  query predicate edges(Function caller, Function callee) {
+    exists(Call call |
+      call.getEnclosingFunction() = caller and
+      (
+        // Static/Direct call
+        callee = call.getTarget()
+        or
+        // Virtual call: if we call a method, any of its overrides could be the actual callee.
+        exists(MemberFunction m |
+          m = call.getTarget() and
+          callee.(MemberFunction).getAnOverriddenFunction+() = m
+        )
       )
     )
-  )
+  }
+
+  class Node = Function;
 }
 
-from GameActionMethod entry, NonDeterministicFunction target, Call call
-where
-  // Transitive closure of the calls predicate to find any path from entry to the call.
-  calls*(entry, call.getEnclosingFunction()) and
-  call.getTarget() = target
-select call, "This call to " + target.getName() + " is reachable from game action method " + entry.getQualifiedName() + "."
+import CallGraphPath
+
+from GameActionMethod source, NonDeterministicFunction sink
+where CallGraphPath::edges*(source, sink)
+select sink, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Call to non-deterministic random function from game action
+ * @description GameActions must be deterministic across all clients. Calling non-deterministic
+ *              random functions like UtilRand or UtilRandNormalDistributed from a GameAction's
+ *              Execute or Query method (or any function they call) can lead to state
+ *              desyncs in multiplayer.
+ * @kind problem
+ * @problem.severity error
+ * @precision high
+ * @id cpp/openrct2/non-deterministic-game-action
+ * @tags reliability
+ *       security
+ *       external/openrct2
+ */
+
+import cpp
+
+/**
+ * A function that is considered non-deterministic for OpenRCT2 game state.
+ * These functions use local entropy or unseeded PRNGs that differ between clients.
+ */
+class NonDeterministicFunction extends Function {
+  NonDeterministicFunction() {
+    this.hasGlobalName("UtilRand") or
+    this.hasGlobalName("UtilRandNormalDistributed") or
+    this.hasGlobalName("rand") or
+    this.hasQualifiedName("std", "rand") or
+    // random_device::operator()
+    exists(Method m |
+      m = this and
+      m.getDeclaringClass().hasQualifiedName("std", "random_device") and
+      m.getName() = "operator()"
+    )
+  }
+}
+
+/**
+ * The Execute or Query methods of a GameAction.
+ * These are the entry points for game state changes or queries that must be deterministic.
+ */
+class GameActionMethod extends Method {
+  GameActionMethod() {
+    exists(Method base |
+      // GameAction is in OpenRCT2::GameActions namespace as per file content
+      base.getDeclaringClass().hasQualifiedName("OpenRCT2::GameActions", "GameAction") and
+      (base.getName() = "Execute" or base.getName() = "Query") and
+      this.getAnOverriddenMethod*() = base
+    )
+  }
+}
+
+/**
+ * Predicate to follow the call graph, including virtual calls.
+ */
+predicate calls(Function caller, Function callee) {
+  exists(Call call |
+    call.getEnclosingFunction() = caller and
+    (
+      // Static/Direct call
+      callee = call.getTarget()
+      or
+      // Virtual call: if we call a method, any of its overrides could be the actual callee.
+      exists(Method m |
+        m = call.getTarget() and
+        callee.(Method).getAnOverriddenMethod+() = m
+      )
+    )
+  )
+}
+
+from GameActionMethod entry, NonDeterministicFunction target, Call call
+where
+  // Transitive closure of the calls predicate to find any path from entry to the call.
+  calls*(entry, call.getEnclosingFunction()) and
+  call.getTarget() = target
+select call, "This call to " + target.getName() + " is reachable from game action method " + entry.getQualifiedName() + "."

--- a/codeql/non_deterministic_game_actions.ql
+++ b/codeql/non_deterministic_game_actions.ql
@@ -21,11 +21,7 @@ import cpp
  */
 class NonDeterministicFunction extends Function {
   NonDeterministicFunction() {
-    (
-      this.getName() = "UtilRand" or
-      this.getName() = "UtilRandNormalDistributed"
-    ) or
-    this.hasGlobalName("rand") or
+    this.getName() = ["UtilRand", "UtilRandNormalDistributed", "rand"] or
     this.hasQualifiedName("std", "rand") or
     // random_device::operator()
     exists(MemberFunction m |
@@ -64,10 +60,12 @@ module CallGraphPath {
         // Static/Direct call
         callee = call.getTarget()
         or
-        // Virtual call: if we call a method, any of its overrides could be the actual callee.
+        // Virtual call: follow overrides, but avoid the generic dispatch noise through GameAction base
         exists(MemberFunction m |
           m = call.getTarget() and
-          callee.(MemberFunction).getAnOverriddenFunction+() = m
+          callee.(MemberFunction).getAnOverriddenFunction+() = m and
+          // Avoid noise from broad interfaces
+          not m.getDeclaringType().hasQualifiedName("OpenRCT2::GameActions", "GameAction")
         )
       )
     )
@@ -78,6 +76,8 @@ module CallGraphPath {
 
 import CallGraphPath
 
-from GameActionMethod source, NonDeterministicFunction sink
-where CallGraphPath::edges*(source, sink)
-select sink, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."
+from GameActionMethod source, NonDeterministicFunction sink, Call call
+where
+  CallGraphPath::edges*(source, call.getEnclosingFunction()) and
+  call.getTarget() = sink
+select call, source, sink, "Non-deterministic call to " + sink.getName() + " reachable from game action method " + source.getQualifiedName() + "."


### PR DESCRIPTION
I have created a CodeQL query to help identify potential sources of non-determinism in OpenRCT2's game actions.

### Changes:
- Added `codeql/non_deterministic_game_actions.ql`:
    - Targets `OpenRCT2::GameActions::GameAction::Execute` and `OpenRCT2::GameActions::GameAction::Query`.
    - Recursively traverses the call graph, including virtual method dispatch.
    - Flags calls to `UtilRand`, `UtilRandNormalDistributed`, `rand`, `std::rand`, and `std::random_device::operator()`.

This query is designed to be run against a CodeQL database of the OpenRCT2 codebase to find desync-causing bugs, such as the known issue in `TrackDesignAction::Execute` calling `RideGetUnusedPresetVehicleColour`.

---
*PR created automatically by Jules for task [13150264571571363099](https://jules.google.com/task/13150264571571363099) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added static analysis tooling that reports non-deterministic calls reachable from game-action entry points, while suppressing findings originating from UI, audio, and other local-only subsystems. This helps surface runtime-nondeterminism risks in gameplay call paths for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->