### PR TITLE
Fix CJK font rendering regression with MSVC 17.10

### DIFF
--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -77,8 +77,8 @@ in the result FT_Bitmap after the FT_Render_Glyph() call. */
 #    define NUM_GRAYS 256
 
 /* Handy routines for converting from fixed point */
-#    define FT_FLOOR(X) (((X) & -64) / 64)
-#    define FT_CEIL(X) ((((X) + 63) & -64) / 64)
+#    define FT_FLOOR(X) ((X) >> 6)
+#    define FT_CEIL(X) (((X) + 63) >> 6)
 
 #    define CACHED_METRICS 0x10
 #    define CACHED_BITMAP 0x01
@@ -97,7 +97,7 @@ struct c_glyph
     int maxy;
     int yoffset;
     int advance;
-    uint16_t cached;
+    uint32_t cached;
 };
 
 /* The structure used to hold internal font information */
@@ -575,7 +575,7 @@ static void Flush_Cache(TTF_Font* font)
     }
 }
 
-static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int want)
+static FT_Error Load_Glyph(TTF_Font* font, uint32_t ch, c_glyph* cached, int want)
 {
     FT_Face face;
     FT_Error error;
@@ -965,12 +965,12 @@ static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int wan
     return 0;
 }
 
-static FT_Error Find_Glyph(TTF_Font* font, uint16_t ch, int want)
+static FT_Error Find_Glyph(TTF_Font* font, uint32_t ch, int want)
 {
     int retval = 0;
     int hsize = sizeof(font->cache) / sizeof(font->cache[0]);
 
-    int h = ch % hsize;
+    uint32_t h = ch % hsize;
     font->current = &font->cache[h];
 
     if (font->current->cached != ch)
@@ -1158,7 +1158,7 @@ int TTF_SizeUTF8(TTF_Font* font, const char* text, int* w, int* h)
     x = 0;
     while (textlen > 0)
     {
-        uint16_t c = UTF8_getch(&text, &textlen);
+        uint32_t c = UTF8_getch(&text, &textlen);
         if (c == UNICODE_BOM_NATIVE || c == UNICODE_BOM_SWAPPED)
         {
             continue;
@@ -1312,7 +1312,7 @@ TTFSurface* TTF_RenderUTF8(TTF_Font* font, const char* text, bool shaded)
     xstart = 0;
     while (textlen > 0)
     {
-        uint16_t c = UTF8_getch(&text, &textlen);
+        uint32_t c = UTF8_getch(&text, &textlen);
         if (c == UNICODE_BOM_NATIVE || c == UNICODE_BOM_SWAPPED)
         {
             continue;

--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -77,8 +77,17 @@ in the result FT_Bitmap after the FT_Render_Glyph() call. */
 #    define NUM_GRAYS 256
 
 /* Handy routines for converting from fixed point */
-#    define FT_FLOOR(X) ((X) >> 6)
-#    define FT_CEIL(X) (((X) + 63) >> 6)
+template<typename T>
+static constexpr T FT_FLOOR(T x)
+{
+    return (x >> 6);
+}
+
+template<typename T>
+static constexpr T FT_CEIL(T x)
+{
+    return ((x + 63) >> 6);
+}
 
 #    define CACHED_METRICS 0x10
 #    define CACHED_BITMAP 0x01


### PR DESCRIPTION
This PR fixes a reported regression where CJK (specifically Korean) users experienced vertical line artifacts in font rendering when the game was compiled with the latest MSVC (17.10+).

The cause was twofold:
1. A known MSVC 17.10 optimizer bug miscompiling the `(x & -64) / 64` pattern in `FT_FLOOR`/`FT_CEIL` macros. Replacing these with arithmetic right shifts (`>> 6`) resolves the miscalculation.
2. The internal font engine was using `uint16_t` for some codepoint storage and lookups, which is insufficient for many CJK characters. Upgrading to `uint32_t` ensures proper support and avoids cache collisions for characters outside the BMP.

The fix only affects the internal `TTFSDLPort` rasterizer used on Windows and does not impact other platforms. Tests confirm that bit shifts are already correctly used for kerning and other metric calculations in the same file.

---
*PR created automatically by Jules for task [6954703900088032462](https://jules.google.com/task/6954703900088032462) started by @janisozaur*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Unicode character support and UTF-8 text handling in font rendering to improve compatibility with wider character sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->